### PR TITLE
Major refactoring of s-expression handling

### DIFF
--- a/src/kiutils/board.py
+++ b/src/kiutils/board.py
@@ -24,8 +24,7 @@ from kiutils.items.brditems import *
 from kiutils.items.gritems import *
 from kiutils.items.dimensions import Dimension
 from kiutils.utils.string_utils import dequote
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
 from kiutils.footprint import Footprint
 from kiutils.misc.config import *
 from kiutils.utils.parsing_utils import parse_bool, format_bool
@@ -188,7 +187,7 @@ class Board():
             raise Exception("Given path is not a file!")
 
         with open(filepath, 'r', encoding=encoding) as infile:
-            item = cls.from_sexpr(sexpr.parse_sexp(infile.read()))
+            item = cls.from_sexpr(parse_sexp(infile.read()))
             item.filePath = filepath
             return item
 
@@ -270,87 +269,78 @@ class Board():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        addNewLine = False
+    def _to_sexpr_raw(self):
+        expr = [
+            'kicad_pcb',
+            ['version', self.version],
+            ['generator', quote(self.generator)]]
 
-        generator_version = f' (generator_version "{self.generator_version}")' if self.generator_version is not None else ''
-        expression =  f'{indents}(kicad_pcb (version {self.version}) (generator "{self.generator}"){generator_version}\n\n'
-        expression += self.general.to_sexpr(indent+2) + '\n'
-        expression += self.paper.to_sexpr(indent+2)
+        # Add generator_version if it exists
+        if self.generator_version is not None:
+            expr.append(['generator_version', quote(self.generator_version)])
+
+        # Add the general, paper, and title block
+        expr.append(self.general._to_sexpr_raw())
+        expr.append(self.paper._to_sexpr_raw())
         if self.titleBlock is not None:
-            expression += self.titleBlock.to_sexpr(indent+2) + '\n'
-        expression += f'{indents}  (layers\n'
-        for layer in self.layers:
-            expression += layer.to_sexpr(indent+4)
-        expression += f'{indents}  )\n\n'
-        expression += self.setup.to_sexpr(indent+2) + '\n'
-        # Properties, if any
+            expr.append(self.titleBlock._to_sexpr_raw())
+
+        # Layers
+        expr.append(['layers'] + [layer._to_sexpr_raw() for layer in self.layers])
+
+        # Setup
+        expr.append(self.setup._to_sexpr_raw())
+
+        # Properties
         if len(self.properties) > 0:
-            for key, value in self.properties.items():
-                expression += f'  (property "{dequote(key)}" "{dequote(value)}")\n'
-            expression += '\n'
+            expr.append([
+                ['property', escape_and_quote(key), escape_and_quote(value)]
+                for key, value in self.properties.items()
+            ])
 
         # Nets
         if len(self.nets) > 0:
-            for net in self.nets:
-                expression += net.to_sexpr(indent=indent+2, newline=True)
-            expression += '\n'
+            expr.extend(net._to_sexpr_raw() for net in self.nets)
 
         # Footprints
-        for footprint in self.footprints:
-            expression += footprint.to_sexpr(indent+2, layerInFirstLine=True) + '\n'
+        expr.extend(footprint._to_sexpr_raw() for footprint in self.footprints)
 
-        # Lines, Texts, Arcs and other graphical items
+        # Graphic items
         if len(self.graphicItems) > 0:
-            addNewLine = True
-            for item in self.graphicItems:
-                if isinstance(item, GrPoly):
-                    expression += item.to_sexpr(indent+2, pts_newline=True)
-                else:
-                    expression += item.to_sexpr(indent+2)
+            expr.extend(item._to_sexpr_raw() for item in self.graphicItems)
 
         # Dimensions
         if len(self.dimensions) > 0:
-            addNewLine = True
-            for dimension in self.dimensions:
-                expression += dimension.to_sexpr(indent+2)
+            expr.extend(dimension._to_sexpr_raw() for dimension in self.dimensions)
 
-        # Target markers:
+        # Target markers
         if len(self.targets) > 0:
-            addNewLine = True
-            for target in self.targets:
-                expression += target.to_sexpr(indent+2)
+            expr.extend(target._to_sexpr_raw() for target in self.targets)
 
-        if addNewLine:
-            expression += '\n'
-
-        # Segments, vias and arcs
+        # Trace items
         if len(self.traceItems) > 0:
-            for item in self.traceItems:
-                expression += item.to_sexpr(indent+2)
-            expression += '\n'
+            expr.extend(item._to_sexpr_raw() for item in self.traceItems)
 
         # Zones
-        for zone in self.zones:
-            expression += zone.to_sexpr(indent+2)
+        expr.extend(zone._to_sexpr_raw() for zone in self.zones)
 
         # Groups
-        for group in self.groups:
-            expression += group.to_sexpr(indent+2)
+        expr.extend(group._to_sexpr_raw() for group in self.groups)
 
-        for generated in self.generated:
-            expression += generated.to_sexpr(indent+2)
+        # Generated items
+        expr.extend(generated._to_sexpr_raw() for generated in self.generated)
 
+        # Embedded fonts
         if self.embedded_fonts is not None:
-            expression += f'{indents} {format_bool("embedded_fonts", self.embedded_fonts, compact=False, yesno=True)}\n'
+            expr.append(format_bool_raw('embedded_fonts', self.embedded_fonts, compact=False, yesno=True))
 
+        # Embedded files
         if len(self.embedded_files) > 0:
-            expression += '(embedded_files'
-            for f in self.embedded_files:
-                expression += f' {f.to_sexpr(indent+2)}'
-            expression += ')'
+            embedded_files_expr = ['embedded_files'] + [f._to_sexpr_raw() for f in self.embedded_files]
+            expr.append(embedded_files_expr)
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+

--- a/src/kiutils/board.py
+++ b/src/kiutils/board.py
@@ -99,7 +99,7 @@ class Board():
     """The ``generator_version`` token attribute defines the version of the program used to write the file"""
 
     embedded_fonts: Optional[bool] = None
-    """The ``embeddedFonts`` indicates that there are fonts embedded into this component"""
+    """The ``embedded_fonts`` indicates that there are fonts embedded into this component"""
 
     embedded_files: list[EmbeddedFile] = field(default_factory=list)
     """The ``embedded_files`` store data of embedded files"""
@@ -276,15 +276,15 @@ class Board():
         expr = [
             'kicad_pcb',
             ['version', self.version],
-            ['generator', quote(self.generator)]]
+            ['generator', quote(self.generator)],
+        ]
 
-        # Add generator_version if it exists
         if self.generator_version is not None:
             expr.append(['generator_version', quote(self.generator_version)])
 
-        # Add the general, paper, and title block
         expr.append(self.general._to_sexpr_raw())
         expr.append(self.paper._to_sexpr_raw())
+
         if self.titleBlock is not None:
             expr.append(self.titleBlock._to_sexpr_raw())
 
@@ -296,10 +296,8 @@ class Board():
 
         # Properties
         if len(self.properties) > 0:
-            expr.append([
-                ['property', escape_and_quote(key), escape_and_quote(value)]
-                for key, value in self.properties.items()
-            ])
+            for key, value in self.properties.items():
+                expr.append(['property', escape_and_quote(key), escape_and_quote(value)])
 
         # Nets
         if len(self.nets) > 0:

--- a/src/kiutils/dru.py
+++ b/src/kiutils/dru.py
@@ -19,9 +19,8 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 from os import path
 
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
+from kiutils.utils.string_utils import *
 
 @dataclass
 class Constraint():
@@ -100,7 +99,7 @@ class Constraint():
 
         return object
 
-    def to_sexpr(self, indent=2, newline=True):
+    def to_sexpr(self, indent=2, newline=True) -> str:
         """Generate the S-Expression representing this object
 
         Args:
@@ -110,16 +109,24 @@ class Constraint():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        min = f' (min "{dequote(self.min)}")' if self.min is not None else ''
-        opt = f' (opt "{dequote(self.opt)}")' if self.opt is not None else ''
-        max = f' (max "{dequote(self.max)}")' if self.max is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['constraint', self.type]
 
-        elements = ' '+' '.join(self.elements) if (len(self.elements) > 0) else ''
+        if self.min is not None:
+            expr.append(['min', escape_and_quote(self.min)])
+        if self.opt is not None:
+            expr.append(['opt', escape_and_quote(self.opt)])
+        if self.max is not None:
+            expr.append(['max', escape_and_quote(self.max)])
 
-        return f'{indents}(constraint {self.type}{min}{opt}{max}{elements}){endline}'
+        if len(self.elements) > 0:
+            expr.extend(self.elements)
+
+        return expr
+
 
 @dataclass
 class Rule():
@@ -179,7 +186,7 @@ class Rule():
 
         return object
 
-    def to_sexpr(self, indent: int = 0):
+    def to_sexpr(self, indent: int = 0) -> str:
         """Generate the S-Expression representing this object
 
         Args:
@@ -188,18 +195,25 @@ class Rule():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(rule "{dequote(self.name)}"\n'
+    def _to_sexpr_raw(self, indent: int = 0):
+        expr = ['rule', escape_and_quote(self.name)]
+
         if self.layer is not None:
-            expression += f'{indents}  (layer {dequote(self.layer)})\n'
+            expr.append(['layer', dequote(self.layer)])
+
         for item in self.constraints:
-            expression += f'{indents}{item.to_sexpr(indent+2)}'
-        expression += f'{indents}  (condition "{dequote(self.condition)}")'
+            expr.append(item._to_sexpr_raw())
+
+        expr.append(['condition', escape_and_quote(self.condition)])
+
         if self.severity is not None:
-            expression += f'\n{indents}  (severity {dequote(self.severity)})'
-        expression += ')\n'
-        return expression
+            expr.append(['severity', dequote(self.severity)])
+
+        return expr
+
 
 @dataclass
 class DesignRules():
@@ -267,7 +281,7 @@ class DesignRules():
             # This dirty fix adds opening and closing brackets `(..)` to the read input to enable
             # the S-Expression parser to work for the DRU-format as well.
             data = f'({infile.read()})'
-            item = cls.from_sexpr(sexpr.parse_sexp(data))
+            item = cls.from_sexpr(parse_sexp(data))
             item.filePath = filepath
             return item
 
@@ -301,7 +315,7 @@ class DesignRules():
             pre_formatted_sexpr = self.to_sexpr()
             outfile.write(prettify(pre_formatted_sexpr))
 
-    def to_sexpr(self, indent=0, newline=False):
+    def to_sexpr(self, indent=0, newline=False) -> str:
         """Generate the S-Expression representing this object
 
         Args:
@@ -311,14 +325,13 @@ class DesignRules():
         Returns:
             str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        # Join the expressions together without extra nesting
+        expr_str = ' '.join(sexp_to_string(item) for item in raw_expr)
+        return expr_str
 
-        expression = f'{indents}(version {self.version})\n'
+    def _to_sexpr_raw(self):
+        expr = ['version', self.version]
+        rules_expr = [rule._to_sexpr_raw() for rule in self.rules]
+        return [expr] + rules_expr
 
-        if len(self.rules):
-            expression += f'{indents}\n'
-            for rule in self.rules:
-                expression += f'{indents}{rule.to_sexpr(indent=indent)}'
-
-        return expression + endline

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -25,12 +25,11 @@ from kiutils.items.zones import Zone
 from kiutils.items.common import Image, Coordinate, Net, Group, Font
 from kiutils.items.fpitems import *
 from kiutils.items.gritems import *
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
-from kiutils.utils.string_utils import dequote, remove_prefix
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string
+from kiutils.utils.string_utils import *
 from kiutils.misc.config import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool, format_bool_raw
 
 @dataclass
 class Attributes():
@@ -122,24 +121,33 @@ class Attributes():
             - str: S-Expression of this object
         """
         if (self.type is None
-            and self.boardOnly == False
-            and self.excludeFromBom == False
-            and self.excludeFromPosFiles == False
-            and self.allowMissingCourtyard == False):
+                and self.boardOnly == False
+                and self.excludeFromBom == False
+                and self.excludeFromPosFiles == False
+                and self.allowMissingCourtyard == False):
             return ''
 
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        type = f' {self.type}' if self.type is not None else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(attr{type}'
-        expression += f' {format_bool("board_only", self.boardOnly, compact=True)}'
-        expression += f' {format_bool("exclude_from_pos_files", self.excludeFromPosFiles, compact=True)}'
-        expression += f' {format_bool("exclude_from_bom", self.excludeFromBom, compact=True)}'
-        expression += f' {format_bool("allow_missing_courtyard", self.allowMissingCourtyard, compact=True)}'
-        expression += f' {format_bool("dnp", self.dnp, compact=True)}' if self.dnp else ''
-        expression += f'){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        expr = ['attr']
+
+        if self.type is not None:
+            expr.append(self.type)
+        if self.boardOnly:
+            expr.append('board_only')
+        if self.excludeFromPosFiles:
+            expr.append('exclude_from_pos_files')
+        if self.excludeFromBom:
+            expr.append('exclude_from_bom')
+        if self.allowMissingCourtyard:
+            expr.append('allow_missing_courtyard')
+        if self.dnp:
+            expr.append('dnp')
+
+        return expr
+
 
 @dataclass
 class Model():
@@ -213,18 +221,23 @@ class Model():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        hide = f' {format_bool("hide", self.hide)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(model "{dequote(self.path)}"{hide}\n'
+    def _to_sexpr_raw(self):
+        expr = ['model', escape_and_quote(self.path)]
+
+        expr.append(format_bool_raw('hide', self.hide))
+
         if self.opacity is not None:
-            expression += f'{indents}  (opacity {self.opacity})\n'
-        expression += f'{indents}  (offset {self.pos.to_sexpr()})\n'
-        expression += f'{indents}  (scale {self.scale.to_sexpr()})\n'
-        expression += f'{indents}  (rotate {self.rotate.to_sexpr()})\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['opacity', self.opacity])
+
+        expr.append(['offset', self.pos._to_sexpr_raw()])
+        expr.append(['scale', self.scale._to_sexpr_raw()])
+        expr.append(['rotate', self.rotate._to_sexpr_raw()])
+
+        return expr
+
 
 @dataclass
 class DrillDefinition():
@@ -293,15 +306,27 @@ class DrillDefinition():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        diameter = f' {self.diameter}' if self.diameter is not None else ''
-        oval = f' oval' if self.oval else ''
-        width = f' {self.width}' if self.oval and self.width is not None else ''
-        offset = f' (offset {format_float(self.offset.X)} {format_float(self.offset.Y)})' if self.offset is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['drill']
 
-        return f'{indents}(drill{oval}{diameter}{width}{offset}){endline}'
+        if self.oval:
+            expr.append('oval')
+
+        if self.diameter is not None:
+            expr.append(self.diameter)
+
+        if self.oval and self.width is not None:
+            expr.append(self.width)
+
+        if self.offset is not None:
+            offset = ['offset', format_float(self.offset.X), format_float(self.offset.Y)]
+            expr.append(offset)
+
+        return expr
+
 
 @dataclass
 class PadOptions():
@@ -360,10 +385,12 @@ class PadOptions():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(options (clearance {self.clearance}) (anchor {self.anchor})){endline}'
+    def _to_sexpr_raw(self):
+        return ['options', ['clearance', self.clearance], ['anchor', self.anchor]]
+
 
 @dataclass
 class Pad():
@@ -585,109 +612,106 @@ class Pad():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        champferFound, marginFound, schematicSymbolAssociated = False, False, False
-        c, cr, smm, spm, spmr, cl, zc, tw, tg, tbw, tba = '', '', '', '', '', '', '', '', '', '', ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        layers = ' (layers'
-        for layer in self.layers:
-            layers += f' "{dequote(layer)}"'
-        layers += ')'
+    def _to_sexpr_raw(self):
+        expr = [
+            'pad',
+            escape_and_quote(self.number),
+            self.type,
+            self.shape
+        ]
 
-        locked = f' {format_bool("locked", self.locked)}'
-        drill = f' {self.drill.to_sexpr()}' if self.drill is not None else ''
-        ppty = f' (property {self.property})' if self.property is not None else ''
-        rul = f' (remove_unused_layers {self.removeUnusedLayers})' if self.removeUnusedLayers is not None else ''
-        kel = f' (keep_end_layers {self.keepEndLayers})' if self.keepEndLayers is not None else ''
-        rrr = f' (roundrect_rratio {self.roundrectRatio})' if self.roundrectRatio is not None else ''
-        zlc = f' {format_bool("zone_layer_connections", self.zone_layer_connections)}'
+        expr.append(format_bool_raw('locked', self.locked))
 
-        net = f' {self.net.to_sexpr()}' if self.net is not None else ''
-        pf = f' (pinfunction "{dequote(self.pinFunction)}")' if self.pinFunction is not None else ''
-        pt = f' (pintype "{dequote(self.pinType)}")' if self.pinType is not None else ''
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
 
-        # Check if a schematic symbol is associated with this footprint. This is usually set, if the
-        # footprint is used in a board file.
-        if net != '' or pf != '' or pt != '':
-            schematicSymbolAssociated = True
+        expr.append(['size', format_float(self.size.X), format_float(self.size.Y)])
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
+        if self.drill is not None:
+            expr.append(self.drill._to_sexpr_raw())
+
+        if self.property is not None:
+            expr.append(['property', self.property])
+
+        layers = ['layers'] + [escape_and_quote(layer) for layer in self.layers]
+        expr.append(layers)
+
+        if self.removeUnusedLayers is not None:
+            expr.append(['remove_unused_layers', self.removeUnusedLayers])
+
+        if self.keepEndLayers is not None:
+            expr.append(['keep_end_layers', self.keepEndLayers])
+
+        if self.roundrectRatio is not None:
+            expr.append(['roundrect_rratio', self.roundrectRatio])
+
+        expr.append(format_bool_raw('zone_layer_connections', self.zone_layer_connections))
+
+        if self.chamferRatio is not None:
+            expr.append(['chamfer_ratio', self.chamferRatio])
 
         if len(self.chamfer) > 0:
-            champferFound = True
-            c = ' (chamfer'
-            for chamfer in self.chamfer:
-                c += f' {chamfer}'
-            c += ')'
-        if self.chamferRatio is not None:
-            champferFound = True
-            cr = f' (chamfer_ratio {self.chamferRatio})'
-
-        if self.position.angle is not None:
-            position = f' (at {format_float(self.position.X)} {format_float(self.position.Y)} {self.position.angle})'
-        else:
-            position = f' (at {format_float(self.position.X)} {format_float(self.position.Y)})'
-
-        if self.solderMaskMargin is not None:
-            marginFound = True
-            smm = f' (solder_mask_margin {self.solderMaskMargin})'
-
-        if self.solderPasteMargin is not None:
-            marginFound = True
-            spm = f' (solder_paste_margin {self.solderPasteMargin})'
-
-        if self.solderPasteMarginRatio is not None:
-            marginFound = True
-            spmr = f' (solder_paste_margin_ratio {self.solderPasteMarginRatio})'
-
-        if self.clearance is not None:
-            marginFound = True
-            cl = f' (clearance {self.clearance})'
-
-        if self.zoneConnect is not None:
-            marginFound = True
-            zc = f' (zone_connect {self.zoneConnect})'
-
-        if self.thermal_bridge_width is not None:
-            tbw = f' (thermal_bridge_width {self.thermal_bridge_width})'
-
-        if self.thermal_bridge_angle is not None:
-            tba = f' (thermal_bridge_angle {self.thermal_bridge_angle})'
-
-        if self.thermalWidth is not None:
-            marginFound = True
-            tw = f' (thermal_width {self.thermalWidth})'
-
-        if self.thermalGap is not None:
-            marginFound = True
-            tg = f' (thermal_gap {self.thermalGap})'
-
-        expression =  (f'{indents}(pad "{dequote(str(self.number))}" {self.type} {self.shape}{locked}{position} '
-                       f'(size {format_float(self.size.X)} {format_float(self.size.Y)}){drill}{ppty}{layers}{rul}{kel}{rrr}{zlc}')
-        if champferFound:
-            # Only one whitespace here as all temporary strings have at least one leading whitespace
-            expression += f'\n{indents} {cr}{c}'
+            chamfer_expr = ['chamfer'] + self.chamfer
+            expr.append(chamfer_expr)
 
         if self.dieLength is not None:
-            expression += f'\n{indents}  (die_length {self.dieLength})'
+            expr.append(['die_length', self.dieLength])
 
-        if marginFound or schematicSymbolAssociated:
-            # Only one whitespace here as all temporary strings have at least one leading whitespace
-            expression += f'\n{indents} {net}{pf}{pt}{smm}{spm}{spmr}{cl}{zc}{tw}{tbw}{tba}{tg}'
+        if self.net is not None:
+            expr.append(self.net._to_sexpr_raw())
+
+        if self.pinFunction is not None:
+            expr.append(['pinfunction', escape_and_quote(self.pinFunction)])
+
+        if self.pinType is not None:
+            expr.append(['pintype', escape_and_quote(self.pinType)])
+
+        if self.solderMaskMargin is not None:
+            expr.append(['solder_mask_margin', self.solderMaskMargin])
+
+        if self.solderPasteMargin is not None:
+            expr.append(['solder_paste_margin', self.solderPasteMargin])
+
+        if self.solderPasteMarginRatio is not None:
+            expr.append(['solder_paste_margin_ratio', self.solderPasteMarginRatio])
+
+        if self.clearance is not None:
+            expr.append(['clearance', self.clearance])
+
+        if self.zoneConnect is not None:
+            expr.append(['zone_connect', self.zoneConnect])
+
+        if self.thermalWidth is not None:
+            expr.append(['thermal_width', self.thermalWidth])
+
+        if self.thermal_bridge_width is not None:
+            expr.append(['thermal_bridge_width', self.thermal_bridge_width])
+
+        if self.thermal_bridge_angle is not None:
+            expr.append(['thermal_bridge_angle', self.thermal_bridge_angle])
+
+        if self.thermalGap is not None:
+            expr.append(['thermal_gap', self.thermalGap])
 
         if self.customPadOptions is not None:
-            expression += f'\n{indents}  {self.customPadOptions.to_sexpr()}'
+            expr.append(self.customPadOptions._to_sexpr_raw())
 
-        if self.customPadPrimitives is not None:
-            if len(self.customPadPrimitives) > 0:
-                expression += f'\n{indents}  (primitives'
-                for primitive in self.customPadPrimitives:
-                    expression += f'\n{primitive.to_sexpr(newline=False,indent=indent+4)}'
-                expression += f'\n{indents}  )'
+        if self.customPadPrimitives is not None and len(self.customPadPrimitives) > 0:
+            primitives = ['primitives']
+            for primitive in self.customPadPrimitives:
+                primitives.append(primitive._to_sexpr_raw())
+            expr.append(primitives)
 
-        expression += f'{tstamp}){endline}'
-        return expression
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class Footprint():
@@ -872,11 +896,13 @@ class Footprint():
     """The ``generator_version`` token attribute defines the version of the program used to write the file"""
 
     embedded_fonts: Optional[str] = None
-    """The ``embedded_fonts`` token defines if the embedded fonts are used in the footprint."""
+    """The ``embedded_fonts`` token defines if the embedded fonts are used in the footprint"""
 
     sheet_name: str = ""
+    """The ``sheet_name`` token defines name of the hierarchical sheet in which this footprint instance was placed."""
 
     sheet_file: str = ""
+    """The ``sheet_file`` token defines filename of the schematic sheet file associated with this footprint instance."""
 
     @classmethod
     def from_sexpr(cls, exp: list) -> Footprint:
@@ -1060,93 +1086,113 @@ class Footprint():
         Returns:
             - str: S-Expression of this object
         """
+        raw_expr = self._to_sexpr_raw(layerInFirstLine=layerInFirstLine)
+        return sexp_to_string(raw_expr)
 
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+    def _to_sexpr_raw(self, layerInFirstLine=False):
+        expr = ['footprint', escape_and_quote(self.libId)]
 
-        locked = f' {format_bool("locked", self.locked)}'
-        placed = f' {format_bool("placed", self.placed)}'
-        version = f' (version {self.version})' if self.version is not None else ''
-        generator = f' (generator "{self.generator}")' if self.generator is not None else ''
-        generator_version = f' (generator_version "{self.generator_version}")' if self.generator_version is not None else ''
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(format_bool_raw('placed', self.placed))
 
-        expression =  f'{indents}(footprint "{dequote(self.libId)}"{locked}{placed}{version}{generator}{generator_version}'
+        if self.version is not None:
+            expr.append(['version', self.version])
+
+        if self.generator is not None:
+            expr.append(['generator', self.generator])
+
+        if self.generator_version is not None:
+            expr.append(['generator_version', self.generator_version])
+
         if layerInFirstLine:
-            expression += f' (layer "{dequote(self.layer)}")\n'
-        else:
-            expression += f'\n{indents}  (layer "{dequote(self.layer)}")\n'
+            expr.append(['layer', escape_and_quote(self.layer)])
 
-        expression += f'{indents} (uuid "{self.tstamp}")' if self.tstamp is not None else ''
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        if not layerInFirstLine:
+            expr.append(['layer', escape_and_quote(self.layer)])
 
         if self.position is not None:
-            angle = f' {self.position.angle}' if self.position.angle is not None else ''
-            expression += f'{indents}  (at {format_float(self.position.X)} {format_float(self.position.Y)}{angle})\n'
+            pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+            if self.position.angle is not None:
+                pos.append(self.position.angle)
+            expr.append(pos)
+
         if self.description is not None:
-            expression += f'{indents}  (descr "{dequote(self.description)}")\n'
+            expr.append(['descr', escape_and_quote(self.description)])
+
         if self.tags is not None:
-            expression += f'{indents}  (tags "{dequote(self.tags)}")\n'
+            expr.append(['tags', escape_and_quote(self.tags)])
+
         for item in self.properties.values():
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
 
         if self.path is not None:
-            expression += f'{indents}  (path "{dequote(self.path)}")\n'
+            expr.append(['path', escape_and_quote(self.path)])
 
         if self.sheet_name != "":
-            expression += f'{indents}  (sheetname "{self.sheet_name}")\n'
+            expr.append(['sheetname', escape_and_quote(self.sheet_name)])
 
         if self.sheet_file != "":
-            expression += f'{indents}  (sheetfile "{self.sheet_file}")\n'
+            expr.append(['sheetfile', escape_and_quote(self.sheet_file)])
 
-        # Additional parameters used in board
         if self.autoplaceCost90 is not None:
-            expression += f'{indents}  (autoplace_cost90 {self.autoplaceCost90})\n'
+            expr.append(['autoplace_cost90', self.autoplaceCost90])
+
         if self.autoplaceCost180 is not None:
-            expression += f'{indents}  (autoplace_cost180 {self.autoplaceCost180})\n'
+            expr.append(['autoplace_cost180', self.autoplaceCost180])
+
         if self.solderMaskMargin is not None:
-            expression += f'{indents}  (solder_mask_margin {self.solderMaskMargin})\n'
+            expr.append(['solder_mask_margin', self.solderMaskMargin])
+
         if self.solderPasteMargin is not None:
-            expression += f'{indents}  (solder_paste_margin {self.solderPasteMargin})\n'
+            expr.append(['solder_paste_margin', self.solderPasteMargin])
+
         if self.solderPasteRatio is not None:
-            expression += f'{indents}  (solder_paste_ratio {self.solderPasteRatio})\n'
+            expr.append(['solder_paste_ratio', self.solderPasteRatio])
+
         if self.clearance is not None:
-            expression += f'{indents}  (clearance {self.clearance})\n'
+            expr.append(['clearance', self.clearance])
+
         if self.zoneConnect is not None:
-            expression += f'{indents}  (zone_connect {self.zoneConnect})\n'
+            expr.append(['zone_connect', self.zoneConnect])
+
         if self.thermalWidth is not None:
-            expression += f'{indents}  (thermal_width {self.thermalWidth})\n'
+            expr.append(['thermal_width', self.thermalWidth])
+
         if self.thermalGap is not None:
-            expression += f'{indents}  (thermal_gap {self.thermalGap})\n'
+            expr.append(['thermal_gap', self.thermalGap])
 
         if self.attributes is not None:
-            # Note: If the attribute object has only standard values in it, it will return an
-            #       empty string. Therefore, it should create its own newline and indentations only
-            #       when needed.
-            expression += self.attributes.to_sexpr(indent=indent+2, newline=True)
+            raw_attr = self.attributes._to_sexpr_raw()
+            if raw_attr:  # only append if it's not empty
+                expr.append(raw_attr)
+
         if self.privateLayers:
-            expression += f'{indents}  (private_layers'
-            for item in self.privateLayers:
-                expression += f' "{dequote(item)}"'
-            expression += f')\n'
-            
+            private_layers = ['private_layers'] + [escape_and_quote(item) for item in self.privateLayers]
+            expr.append(private_layers)
+
         if self.netTiePadGroups:
-            expression += f'{indents}  (net_tie_pad_groups'
-            for item in self.netTiePadGroups:
-                expression += f' "{dequote(item)}"'
-            expression += f')\n'
+            net_tie = ['net_tie_pad_groups'] + [escape_and_quote(item) for item in self.netTiePadGroups]
+            expr.append(net_tie)
 
         for item in self.graphicItems:
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
+
         for item in self.pads:
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
+
         for item in self.zones:
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
+
         for item in self.groups:
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
+
         if self.embedded_fonts is not None:
-            expression += f'{indents}  (embedded_fonts {self.embedded_fonts})\n'
+            expr.append(['embedded_fonts', self.embedded_fonts])
+
         for item in self.models:
-            expression += item.to_sexpr(indent=indent+2)
+            expr.append(item._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
-
+        return expr

--- a/src/kiutils/footprint.py
+++ b/src/kiutils/footprint.py
@@ -1086,10 +1086,10 @@ class Footprint():
         Returns:
             - str: S-Expression of this object
         """
-        raw_expr = self._to_sexpr_raw(layerInFirstLine=layerInFirstLine)
+        raw_expr = self._to_sexpr_raw()
         return sexp_to_string(raw_expr)
 
-    def _to_sexpr_raw(self, layerInFirstLine=False):
+    def _to_sexpr_raw(self):
         expr = ['footprint', escape_and_quote(self.libId)]
 
         expr.append(format_bool_raw('locked', self.locked))
@@ -1104,14 +1104,10 @@ class Footprint():
         if self.generator_version is not None:
             expr.append(['generator_version', self.generator_version])
 
-        if layerInFirstLine:
-            expr.append(['layer', escape_and_quote(self.layer)])
+        expr.append(['layer', escape_and_quote(self.layer)])
 
         if self.tstamp is not None:
             expr.append(['uuid', quote(self.tstamp)])
-
-        if not layerInFirstLine:
-            expr.append(['layer', escape_and_quote(self.layer)])
 
         if self.position is not None:
             pos = ['at', format_float(self.position.X), format_float(self.position.Y)]

--- a/src/kiutils/items/brditems.py
+++ b/src/kiutils/items/brditems.py
@@ -19,10 +19,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 
 from kiutils.items.common import Position
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
-
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class GeneralSettings():
@@ -80,15 +80,16 @@ class GeneralSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(general\n'
-        expression += f'{indents}  (thickness {self.thickness})\n'
+    def _to_sexpr_raw(self):
+        expr = ['general', ['thickness', self.thickness]]
+
         if self.legacy_teardrops is not None:
-            expression += f'{indents}  (legacy_teardrops {self.legacy_teardrops})\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['legacy_teardrops', self.legacy_teardrops])
+
+        return expr
 
 
 @dataclass
@@ -149,12 +150,16 @@ class LayerToken():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        username = f' "{dequote(self.userName)}"' if self.userName is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [self.ordinal, escape_and_quote(self.name), self.type]
 
-        return f'{indents}({self.ordinal} "{dequote(self.name)}" {self.type}{username}){endline}'
+        if self.userName is not None:
+            expr.append(escape_and_quote(self.userName))
+
+        return expr
 
 
 @dataclass
@@ -194,14 +199,22 @@ class StackupSubLayer():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        mat = f' (material "{dequote(self.material)}")' if self.material is not None else ''
-        er = f' (epsilon_r {self.epsilonR})' if self.epsilonR is not None else ''
-        lt = f' (loss_tangent {self.lossTangent})' if self.lossTangent is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['addsublayer', ['thickness', self.thickness]]
 
-        return f'{indents}addsublayer (thickness {self.thickness}){mat}{er}{lt}{endline}'
+        if self.material is not None:
+            expr.append(['material', self.material])
+
+        if self.epsilonR is not None:
+            expr.append(['epsilon_r', self.epsilonR])
+
+        if self.lossTangent is not None:
+            expr.append(['loss_tangent', self.lossTangent])
+
+        return expr
 
 
 @dataclass
@@ -315,21 +328,32 @@ class StackupLayer():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        color = f' (color "{dequote(self.color)}")' if self.color is not None else ''
-        material = f' (material "{dequote(self.material)}")' if self.material is not None else ''
-        thickness = f' (thickness {self.thickness})' if self.thickness is not None else ''
-        epsilon_r = f' (epsilon_r {self.epsilonR})' if self.epsilonR is not None else ''
-        loss_tangent = f' (loss_tangent {self.lossTangent})' if self.lossTangent is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['layer', escape_and_quote(self.name), ['type', escape_and_quote(self.type)]]
 
-        expression = f'{indents}(layer "{dequote(self.name)}" (type "{self.type}"){color}{thickness}'
-        expression +=f'{material}{epsilon_r}{loss_tangent}'
+        if self.color is not None:
+            expr.append(['color', escape_and_quote(self.color)])
+
+        if self.thickness is not None:
+            expr.append(['thickness', self.thickness])
+
+        if self.material is not None:
+            expr.append(['material', escape_and_quote(self.material)])
+
+        if self.epsilonR is not None:
+            expr.append(['epsilon_r', self.epsilonR])
+
+        if self.lossTangent is not None:
+            expr.append(['loss_tangent', self.lossTangent])
+
         for layer in self.subLayers:
-            expression += f'\n{layer.to_sexpr(indent+2)}'
-        expression += f'){endline}'
-        return expression
+            expr.append(layer._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class Stackup():
@@ -408,19 +432,32 @@ class Stackup():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(stackup\n'
+    def _to_sexpr_raw(self):
+        expr = ['stackup']
+
         for layer in self.layers:
-            expression += layer.to_sexpr(indent+2)
-        if self.copperFinish is not None:         expression += f'{indents}  (copper_finish "{dequote(self.copperFinish)}")\n'
-        if self.dielectricContraints is not None: expression += f'{indents}  (dielectric_constraints {self.dielectricContraints})\n'
-        if self.edgeConnector is not None:        expression += f'{indents}  (edge_connector {self.edgeConnector})\n'
-        if self.castellatedPads:                  expression += f'{indents}  {format_bool("castellated_pads", self.castellatedPads)}\n'
-        if self.edgePlating:                      expression += f'{indents}  {format_bool("edge_plating", self.edgePlating)}\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(layer._to_sexpr_raw())
+
+        if self.copperFinish is not None:
+            expr.append(['copper_finish', escape_and_quote(self.copperFinish)])
+
+        if self.dielectricContraints is not None:
+            expr.append(['dielectric_constraints', self.dielectricContraints])
+
+        if self.edgeConnector is not None:
+            expr.append(['edge_connector', self.edgeConnector])
+
+        if self.castellatedPads:
+            expr.append(['castellated_pads', self.castellatedPads])
+
+        if self.edgePlating:
+            expr.append(['edge_plating', self.edgePlating])
+
+        return expr
+
 
 @dataclass
 class PlotSettings():
@@ -663,69 +700,98 @@ class PlotSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(pcbplotparams\n'
-        expression += f'{indents}  (layerselection {self.layerSelection})\n'
+    def _to_sexpr_raw(self):
+        expr = ['pcbplotparams', ['layerselection', self.layerSelection]]
+
         if self.plotOnAllLayersSelection is not None:
-            expression += f'{indents}  (plot_on_all_layers_selection {self.plotOnAllLayersSelection})\n'
-        expression += f'{indents}  (disableapertmacros {self.disableApertMacros})\n'
-        expression += f'{indents}  (usegerberextensions {self.useGerberExtensions})\n'
-        expression += f'{indents}  (usegerberattributes {self.useGerberAttributes})\n'
-        expression += f'{indents}  (usegerberadvancedattributes {self.useGerberAdvancedAttributes})\n'
-        expression += f'{indents}  (creategerberjobfile {self.createGerberJobFile})\n'
+            expr.append(['plot_on_all_layers_selection', self.plotOnAllLayersSelection])
+
+        expr.append(['disableapertmacros', self.disableApertMacros])
+        expr.append(['usegerberextensions', self.useGerberExtensions])
+        expr.append(['usegerberattributes', self.useGerberAttributes])
+        expr.append(['usegerberadvancedattributes', self.useGerberAdvancedAttributes])
+        expr.append(['creategerberjobfile', self.createGerberJobFile])
+
         if self.dashedLineDashRatio is not None:
-            expression += f'{indents}  (dashed_line_dash_ratio {float(self.dashedLineDashRatio):.6f})\n'
+            expr.append(['dashed_line_dash_ratio', (f"{self.dashedLineDashRatio:.6f}")])
+
         if self.dashedLineGapRatio is not None:
-            expression += f'{indents}  (dashed_line_gap_ratio {float(self.dashedLineGapRatio):.6f})\n'
+            expr.append(['dashed_line_gap_ratio', (f"{self.dashedLineGapRatio:.6f}")])
+
         if self.svgUseInch is not None:
-            expression += f'{indents}  (svguseinch {self.svgUseInch})\n'
-        expression += f'{indents}  (svgprecision {self.svgPrecision})\n'
+            expr.append(['svguseinch', self.svgUseInch])
+
+        expr.append(['svgprecision', self.svgPrecision])
+
         if self.excludeEdgeLayer is not None:
-            expression += f'{indents}  (excludeedgelayer {self.excludeEdgeLayer})\n'
-        expression += f'{indents}  (plotframeref {self.plotFameRef})\n'
-        expression += f'{indents}  (viasonmask {self.viasOnMask})\n' if self.viasOnMask == 'yes' else ''
-        expression += f'{indents}  (mode {self.mode})\n'
-        expression += f'{indents}  (useauxorigin no)\n'
-        expression += f'{indents}  (hpglpennumber {self.hpglPenNumber})\n'
-        expression += f'{indents}  (hpglpenspeed {self.hpglPenSpeed})\n'
-        expression += f'{indents}  (hpglpendiameter {float(self.hpglPenDiameter):.6f})\n'
+            expr.append(['excludeedgelayer', self.excludeEdgeLayer])
+
+        expr.append(['plotframeref', self.plotFameRef])
+
+        if self.viasOnMask == 'yes':
+            expr.append(['viasonmask', self.viasOnMask])
+
+        expr.append(['mode', self.mode])
+        expr.append(['useauxorigin', 'no'])
+        expr.append(['hpglpennumber', self.hpglPenNumber])
+        expr.append(['hpglpenspeed', self.hpglPenSpeed])
+        expr.append(['hpglpendiameter', (f"{self.hpglPenDiameter:.6f}")])
+
         if self.pdf_front_fp_property_popups is not None:
-            expression += f'{indents}  (pdf_front_fp_property_popups {self.pdf_front_fp_property_popups})\n'
+            expr.append(['pdf_front_fp_property_popups', self.pdf_front_fp_property_popups])
+
         if self.pdf_back_fp_property_popups is not None:
-            expression += f'{indents}  (pdf_back_fp_property_popups {self.pdf_back_fp_property_popups})\n'
+            expr.append(['pdf_back_fp_property_popups', self.pdf_back_fp_property_popups])
+
         if self.pdf_metadata is not None:
-            expression += f'{indents}  (pdf_metadata {self.pdf_metadata})\n'
+            expr.append(['pdf_metadata', self.pdf_metadata])
+
         if self.pdf_single_document is not None:
-            expression += f'{indents}  (pdf_single_document {self.pdf_single_document})\n'
-        expression += f'{indents}  (dxfpolygonmode {self.dxfPolygonMode})\n'
-        expression += f'{indents}  (dxfimperialunits {self.dxfImperialUnits})\n'
-        expression += f'{indents}  (dxfusepcbnewfont {self.dxfUsePcbnewFont})\n'
-        expression += f'{indents}  (psnegative {self.psNegative})\n'
-        expression += f'{indents}  (psa4output {self.psA4Output})\n'
+            expr.append(['pdf_single_document', self.pdf_single_document])
+
+        expr.append(['dxfpolygonmode', self.dxfPolygonMode])
+        expr.append(['dxfimperialunits', self.dxfImperialUnits])
+        expr.append(['dxfusepcbnewfont', self.dxfUsePcbnewFont])
+        expr.append(['psnegative', self.psNegative])
+        expr.append(['psa4output', self.psA4Output])
+
         if self.plot_black_and_white is not None:
-            expression += f'{indents}  (plot_black_and_white {self.plot_black_and_white})\n'
-        expression += f'{indents}  (sketchpadsonfab {self.sketchPadsOnFab})\n'
+            expr.append(['plot_black_and_white', self.plot_black_and_white])
+
+        expr.append(['sketchpadsonfab', self.sketchPadsOnFab])
+
         if self.plot_pad_numbers is not None:
-            expression += f'{indents}  (plotpadnumbers {self.plot_pad_numbers})\n'
+            expr.append(['plotpadnumbers', self.plot_pad_numbers])
+
         if self.hide_dnp_on_fab is not None:
-            expression += f'{indents}  (hidednponfab {self.hide_dnp_on_fab})\n'
+            expr.append(['hidednponfab', self.hide_dnp_on_fab])
+
         if self.sketch_dnp_on_fab is not None:
-            expression += f'{indents}  (sketchdnponfab {self.sketch_dnp_on_fab})\n'
+            expr.append(['sketchdnponfab', self.sketch_dnp_on_fab])
+
         if self.crossout_dnp_on_fab is not None:
-            expression += f'{indents}  (crossoutdnponfab {self.crossout_dnp_on_fab})\n'
-        expression += f'{indents}  (plotreference {self.plotReference})\n' if self.plotReference == 'yes' else ''
-        expression += f'{indents}  (plotvalue {self.plotValue})\n' if self.plotValue == 'yes' else ''
-        expression += f'{indents}  (plotinvisibletext {self.plotInvisibleText})\n' if self.plotInvisibleText == 'yes' else ''
-        expression += f'{indents}  (subtractmaskfromsilk {self.subtractMaskFromSilk})\n'
-        expression += f'{indents}  (outputformat {self.outputFormat})\n'
-        expression += f'{indents}  (mirror {self.mirror})\n'
-        expression += f'{indents}  (drillshape {self.drillShape})\n'
-        expression += f'{indents}  (scaleselection {self.scaleSelection})\n'
-        expression += f'{indents}  (outputdirectory "{dequote(self.outputDirectory)}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['crossoutdnponfab', self.crossout_dnp_on_fab])
+
+        if self.plotReference == 'yes':
+            expr.append(['plotreference', self.plotReference])
+
+        if self.plotValue == 'yes':
+            expr.append(['plotvalue', self.plotValue])
+
+        if self.plotInvisibleText == 'yes':
+            expr.append(['plotinvisibletext', self.plotInvisibleText])
+
+        expr.append(['subtractmaskfromsilk', self.subtractMaskFromSilk])
+        expr.append(['outputformat', self.outputFormat])
+        expr.append(['mirror', self.mirror])
+        expr.append(['drillshape', self.drillShape])
+        expr.append(['scaleselection', self.scaleSelection])
+        expr.append(['outputdirectory', escape_and_quote(self.outputDirectory)])
+
+        return expr
 
 
 @dataclass
@@ -769,14 +835,18 @@ class SetupData():
     """The optional ``plotSettings`` define how the board was last plotted."""
 
     # Available since KiCad v9
+    # TODO Update docs
 
     allow_soldermask_bridges_in_footprints: Optional[str] = None
 
-    # TODO
     tenting: List[str] = field(default_factory=list)
+
     covering: List[str] = field(default_factory=list)
+
     plugging: List[str] = field(default_factory=list)
+
     capping: List[str] = field(default_factory=list)
+
     filling: List[str] = field(default_factory=list)
 
     @classmethod
@@ -833,48 +903,54 @@ class SetupData():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        indents_nest = indents*2
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(setup\n'
+    def _to_sexpr_raw(self):
+        expr = ['setup']
+
         if self.stackup is not None:
-            expression += self.stackup.to_sexpr(indent+2)
+            expr.append(self.stackup._to_sexpr_raw())
 
-        expression += f'{indents_nest}(pad_to_mask_clearance {format_float(self.packToMaskClearance)})\n'
+        expr.append(['pad_to_mask_clearance', format_float(self.packToMaskClearance)])
 
         if self.solderMaskMinWidth is not None:
-            expression += f'{indents_nest}(solder_mask_min_width {self.solderMaskMinWidth})\n'
-        if self.padToPasteClearance is not None:
-            expression += f'{indents_nest}(pad_to_paste_clearance {self.padToPasteClearance})\n'
-        if self.padToPasteClearanceRatio is not None:
-            expression += f'{indents_nest}(pad_to_paste_clearance_ratio {self.padToPasteClearanceRatio})\n'
-        if self.allow_soldermask_bridges_in_footprints is not None:
-            expression += f'{indents_nest}(allow_soldermask_bridges_in_footprints {self.allow_soldermask_bridges_in_footprints})\n'
-        if len(self.tenting) > 0:
-            tenting_joined = ' '.join(self.tenting)
-            expression += f'{indents_nest}(tenting {tenting_joined})\n'
-        if self.auxAxisOrigin is not None:
-            expression += f'{indents_nest}(aux_axis_origin {format_float(self.auxAxisOrigin.X)} {format_float(self.auxAxisOrigin.Y)})\n'
-        if self.gridOrigin is not None:
-            expression += f'{indents_nest}(grid_origin {format_float(self.gridOrigin.X)} {format_float(self.gridOrigin.Y)})\n'
-        if len(self.covering) > 0:
-            covering_joined = ' '.join(self.covering)
-            expression += f'{indents_nest}(covering {covering_joined})\n'
-        if len(self.plugging) > 0:
-            plugging_joined = ' '.join(self.plugging)
-            expression += f'{indents_nest}(plugging {plugging_joined})\n'
-        if len(self.capping) > 0:
-            capping_joined = ' '.join(self.capping)
-            expression += f'{indents_nest}(capping {capping_joined})\n'
-        if len(self.filling) > 0:
-            filling_joined = ' '.join(self.filling)
-            expression += f'{indents_nest}(filling {filling_joined})\n'
-        if self.plotSettings is not None:
-            expression += self.plotSettings.to_sexpr(indent+2)
+            expr.append(['solder_mask_min_width', self.solderMaskMinWidth])
 
-        expression += f'{indents}){endline}'
-        return expression
+        if self.padToPasteClearance is not None:
+            expr.append(['pad_to_paste_clearance', self.padToPasteClearance])
+
+        if self.padToPasteClearanceRatio is not None:
+            expr.append(['pad_to_paste_clearance_ratio', self.padToPasteClearanceRatio])
+
+        if self.allow_soldermask_bridges_in_footprints is not None:
+            expr.append(['allow_soldermask_bridges_in_footprints', self.allow_soldermask_bridges_in_footprints])
+
+        if len(self.tenting) > 0:
+            expr.append(['tenting'] + self.tenting)
+
+        if self.auxAxisOrigin is not None:
+            expr.append(['aux_axis_origin', format_float(self.auxAxisOrigin.X), format_float(self.auxAxisOrigin.Y)])
+
+        if self.gridOrigin is not None:
+            expr.append(['grid_origin', format_float(self.gridOrigin.X), format_float(self.gridOrigin.Y)])
+
+        if len(self.covering) > 0:
+            expr.append(['covering'] + self.covering)
+
+        if len(self.plugging) > 0:
+            expr.append(['plugging'] + self.plugging)
+
+        if len(self.capping) > 0:
+            expr.append(['capping'] + self.capping)
+
+        if len(self.filling) > 0:
+            expr.append(['filling'] + self.filling)
+
+        if self.plotSettings is not None:
+            expr.append(self.plotSettings._to_sexpr_raw())
+
+        return expr
 
 
 @dataclass
@@ -954,13 +1030,28 @@ class Segment():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return (f'{indents}(segment '
-                f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)}) (width {format_float(self.width)})'
-                f'{locked} (layer "{dequote(self.layer)}") (net {self.net}) (uuid "{self.tstamp}")){endline}')
+    def _to_sexpr_raw(self):
+        expr = [
+            'segment',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+            ['width', format_float(self.width)],
+        ]
+
+        if self.locked:
+            expr.append(format_bool_raw("locked", self.locked))
+
+        expr.extend([
+            ['layer', escape_and_quote(self.layer)],
+            ['net', self.net],
+            ['uuid', quote(self.tstamp)]
+        ])
+
+        return expr
+
 
 @dataclass
 class Via():
@@ -1063,24 +1154,50 @@ class Via():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        type = f' {self.type}' if self.type is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+    def _to_sexpr_raw(self):
+        expr = ['via']
 
-        layers = ''
+        if self.type is not None:
+            expr.append(self.type)
+
+        expr.extend([
+            ['at', format_float(self.position.X), format_float(self.position.Y)],
+            ['size', format_float(self.size)],
+            ['drill', self.drill]
+        ])
+
+        layer_list = ['layers']
+
         for layer in self.layers:
-            layers += f' "{dequote(layer)}"'
-        rum = f' {format_bool("remove_unused_layers", self.removeUnusedLayers)}'
-        kel = f' {format_bool("keep_end_layers", self.keepEndLayers)}'
-        free = f' {format_bool("free", self.free)}'
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        zlc = ' (zone_layer_connections)' if self.zone_layer_connections else ''
+            layer_list.append(escape_and_quote(layer))
 
-        return (f'{indents}(via{type} '
-                f'(at {format_float(self.position.X)} {format_float(self.position.Y)}) (size {format_float(self.size)}) (drill {self.drill}) '
-                f'(layers{layers}){rum}{kel}{locked}{free}{zlc} (net {self.net}){tstamp}){endline}')
+        expr.append(layer_list)
+
+        if self.removeUnusedLayers:
+            expr.append(format_bool_raw("remove_unused_layers", self.removeUnusedLayers))
+
+        if self.keepEndLayers:
+            expr.append(format_bool_raw("keep_end_layers", self.keepEndLayers))
+
+        if self.locked:
+            expr.append(format_bool_raw("locked", self.locked))
+
+        if self.free:
+            expr.append(format_bool_raw("free", self.free))
+
+        if self.zone_layer_connections:
+            expr.append(['zone_layer_connections'])
+
+        expr.append(['net', self.net])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class Arc():
@@ -1164,17 +1281,28 @@ class Arc():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        locked = f' {format_bool("locked", self.locked)}'
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['arc']
 
-        expression = f'{indents}(arc{locked} (start {self.start.X} {self.start.Y}) '
-        expression += f'(mid {self.mid.X} {self.mid.Y}) (end {self.end.X} {self.end.Y}) '
-        expression += f'(width {self.width}) (layer "{dequote(self.layer)}") '
-        expression += f'(net {self.net}){tstamp}){endline}'
-        return expression
+        if self.locked:
+            expr.append(format_bool_raw("locked", self.locked))
+
+        expr.extend([
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+            ['width', format_float(self.width)],
+            ['layer', escape_and_quote(self.layer)],
+            ['net', self.net]
+        ])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
 
 
 @dataclass
@@ -1249,11 +1377,20 @@ class Target():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return (f'{indents}(target {self.type} (at {format_float(self.position.X)} {format_float(self.position.Y)}) '
-                f'(size {format_float(self.size)}) (width {format_float(self.width)}) (layer "{self.layer}") (uuid "{self.tstamp}")){endline}')
+    def _to_sexpr_raw(self):
+        return [
+            'target',
+            self.type,
+            ['at', format_float(self.position.X), format_float(self.position.Y)],
+            ['size', format_float(self.size)],
+            ['width', format_float(self.width)],
+            ['layer', quote(self.layer)],
+            ['uuid', quote(self.tstamp)]
+        ]
+
 
 @dataclass
 class Generated():
@@ -1433,60 +1570,57 @@ class Generated():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(generated\n'
-        expression += f'{indents}(uuid "{dequote(self.uuid)}")\n'
-        expression += f'{indents}(type {self.type})\n'
-        expression += f'{indents}(name "{dequote(self.name)}")\n'
-        expression += f'{indents}(layer "{dequote(self.layer)}")\n'
+    def _to_sexpr_raw(self):
+        expr = ['generated']
+
+        expr.append(['uuid', escape_and_quote(self.uuid)])
+        expr.append(['type', self.type])
+        expr.append(['name', escape_and_quote(self.name)])
+        expr.append(['layer', escape_and_quote(self.layer)])
+
         if self.locked:
-            expression += f' {format_bool("locked", self.locked)}'
+            expr.append(format_bool_raw("locked", self.locked))
 
         if len(self.base_line) > 0:
-            expression += f'{indents}(base_line\n'
-            expression += f'{indents*2}(pts\n'
+            base_line_pts = ['pts']
             for point in self.base_line:
-                expression += f' (xy {format_float(point.X)} {format_float(point.Y)})'
-            expression += f'{indents*2})\n' #pts
-            expression += f'{indents}){endline}' #base_line
+                base_line_pts.append(['xy', format_float(point.X), format_float(point.Y)])
+            expr.append(['base_line', base_line_pts])
 
         if len(self.base_line_coupled) > 0:
-            expression += f'{indents}(base_line_coupled\n'
-            expression += f'{indents*2}(pts\n'
-            for point in self.base_line:
-                expression += f' (xy {format_float(point.X)} {format_float(point.Y)})'
-            expression += f'{indents*2})\n' #pts
-            expression += f'{indents}){endline}' #base_line_coupled
+            coupled_pts = ['pts']
+            for point in self.base_line_coupled:
+                coupled_pts.append(['xy', format_float(point.X), format_float(point.Y)])
+            expr.append(['base_line_coupled', coupled_pts])
 
-        expression += f'{indents}(corner_radius_percent {self.corner_radius})\n'
-        expression += f'{indents}(end (xy {format_float(self.end.X)} {format_float(self.end.Y)}))\n'
-        expression += f'{indents}(initial_side "{dequote(self.initial_side)}")\n'
-        expression += f'{indents}(last_diff_pair_gap {self.last_diff_pair_gap})\n'
-        expression += f'{indents}(last_netname "{dequote(self.last_net_name)}")\n'
-        expression += f'{indents}(last_status "{dequote(self.last_status)}")\n'
-        expression += f'{indents}(last_track_width {self.last_track_width})\n'
-        expression += f'{indents}(last_tuning "{dequote(self.last_tuning)}")\n'
-        expression += f'{indents}(max_amplitude {self.max_amplitude})\n'
-        expression += f'{indents}(min_amplitude {self.min_amplitude})\n'
-        expression += f'{indents}(min_spacing {self.min_spacing})\n'
-        expression += f'{indents}(origin (xy {format_float(self.origin.X)} {format_float(self.origin.Y)}))\n'
-        expression += f'{indents}(override_custom_rules {self.override_custom_rules})\n'
-        expression += f'{indents}(rounded {self.rounded})\n'
-        expression += f'{indents}(single_sided {self.single_sided})\n'
-        expression += f'{indents}(target_length {self.target_length})\n'
-        expression += f'{indents}(target_length_max {self.target_length_max})\n'
-        expression += f'{indents}(target_length_min {self.target_length_min})\n'
-        expression += f'{indents}(target_skew {self.target_skew})\n'
-        expression += f'{indents}(target_skew_max {self.target_skew_max})\n'
-        expression += f'{indents}(target_skew_min {self.target_skew_min})\n'
-        expression += f'{indents}(tuning_mode "{dequote(self.tuning_mode)}")\n'
+        expr.append(['corner_radius_percent', self.corner_radius])
+        expr.append(['end', ['xy', format_float(self.end.X), format_float(self.end.Y)]])
+        expr.append(['initial_side', escape_and_quote(self.initial_side)])
+        expr.append(['last_diff_pair_gap', self.last_diff_pair_gap])
+        expr.append(['last_netname', escape_and_quote(self.last_net_name)])
+        expr.append(['last_status', escape_and_quote(self.last_status)])
+        expr.append(['last_track_width', self.last_track_width])
+        expr.append(['last_tuning', escape_and_quote(self.last_tuning)])
+        expr.append(['max_amplitude', self.max_amplitude])
+        expr.append(['min_amplitude', self.min_amplitude])
+        expr.append(['min_spacing', self.min_spacing])
+        expr.append(['origin', ['xy', format_float(self.origin.X), format_float(self.origin.Y)]])
+        expr.append(['override_custom_rules', self.override_custom_rules])
+        expr.append(['rounded', self.rounded])
+        expr.append(['single_sided', self.single_sided])
+        expr.append(['target_length', self.target_length])
+        expr.append(['target_length_max', self.target_length_max])
+        expr.append(['target_length_min', self.target_length_min])
+        expr.append(['target_skew', self.target_skew])
+        expr.append(['target_skew_max', self.target_skew_max])
+        expr.append(['target_skew_min', self.target_skew_min])
+        expr.append(['tuning_mode', escape_and_quote(self.tuning_mode)])
+
         if len(self.members) > 0:
-            expression += f'{indents}(members'
-            for member in self.members:
-                expression += f' "{member}"'
-            expression += f'){endline}'
+            members = ['members'] + [quote(member) for member in self.members]
+            expr.append(members)
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr

--- a/src/kiutils/items/brditems.py
+++ b/src/kiutils/items/brditems.py
@@ -1047,7 +1047,7 @@ class Segment():
         expr.extend([
             ['layer', escape_and_quote(self.layer)],
             ['net', self.net],
-            ['uuid', quote(self.tstamp)]
+            ['uuid', quote(self.tstamp)],
         ])
 
         return expr
@@ -1166,7 +1166,7 @@ class Via():
         expr.extend([
             ['at', format_float(self.position.X), format_float(self.position.Y)],
             ['size', format_float(self.size)],
-            ['drill', self.drill]
+            ['drill', self.drill],
         ])
 
         layer_list = ['layers']
@@ -1296,7 +1296,7 @@ class Arc():
             ['end', format_float(self.end.X), format_float(self.end.Y)],
             ['width', format_float(self.width)],
             ['layer', escape_and_quote(self.layer)],
-            ['net', self.net]
+            ['net', self.net],
         ])
 
         if self.tstamp is not None:
@@ -1388,7 +1388,7 @@ class Target():
             ['size', format_float(self.size)],
             ['width', format_float(self.width)],
             ['layer', quote(self.layer)],
-            ['uuid', quote(self.tstamp)]
+            ['uuid', quote(self.tstamp)],
         ]
 
 
@@ -1574,12 +1574,13 @@ class Generated():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['generated']
-
-        expr.append(['uuid', escape_and_quote(self.uuid)])
-        expr.append(['type', self.type])
-        expr.append(['name', escape_and_quote(self.name)])
-        expr.append(['layer', escape_and_quote(self.layer)])
+        expr = [
+            'generated',
+            ['uuid', escape_and_quote(self.uuid)],
+            ['type', self.type],
+            ['name', escape_and_quote(self.name)],
+            ['layer', escape_and_quote(self.layer)],
+        ]
 
         if self.locked:
             expr.append(format_bool_raw("locked", self.locked))

--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -386,16 +386,16 @@ class Font():
         if self.face is not None:
             expr.append(['face', escape_and_quote(self.face)])
 
-        expr.append(['size', self.height, self.width])
-
-        if self.color is not None:
-            expr.append(self.color._to_sexpr_raw())
+        expr.append(['size', format_float(self.height), format_float(self.width)])
 
         if self.thickness is not None:
             expr.append(['thickness', self.thickness])
 
         if self.bold:
             expr.append(format_bool_raw('bold', self.bold))
+
+        if self.color is not None:
+            expr.append(self.color._to_sexpr_raw())
 
         if self.italic:
             expr.append(format_bool_raw('italic', self.italic))
@@ -554,8 +554,10 @@ class Effects():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['effects']
-        expr.append(self.font._to_sexpr_raw())
+        expr = [
+            'effects',
+            self.font._to_sexpr_raw(),
+        ]
 
         justify_raw = self.justify._to_sexpr_raw()
         if len(justify_raw) > 0:
@@ -690,9 +692,13 @@ class Group():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['group', escape_and_quote(self.name), ['uuid', escape_and_quote(self.id)]]
-        expr.append(format_bool_raw("locked", self.locked))
-        expr.append(['members'] + [quote(member) for member in self.members])
+        expr = [
+            'group',
+            escape_and_quote(self.name),
+            ['uuid', escape_and_quote(self.id)],
+            format_bool_raw("locked", self.locked),
+            ['members'] + [quote(member) for member in self.members],
+        ]
         return expr
 
 
@@ -970,18 +976,18 @@ class Property():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
-
-        if self.position.angle is not None:
-            pos.append(format_float(self.position.angle))
-
         if (self.key in ['Datasheet', 'Sim.Library'] and len(self.value) > 0
                 and self.value not in ['.','~'] and not is_url(self.value)):
             value = str(PureWindowsPath(self.value)).replace("\\", "\\\\")
         else:
             value = self.value
 
-        expr = ['property', escape_and_quote(self.key), escape_and_quote(value), pos]
+        expr = ['property', escape_and_quote(self.key), escape_and_quote(value)]
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
 
         if self.id is not None:
             expr.append(['id', self.id])

--- a/src/kiutils/items/common.py
+++ b/src/kiutils/items/common.py
@@ -23,9 +23,10 @@ from pathlib import Path, PureWindowsPath
 from enum import Enum
 import urllib.parse
 
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 def is_url(path: str) -> bool:
     parsed = urllib.parse.urlparse(path)
@@ -139,9 +140,11 @@ class Coordinate():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        return f'{indents}(xyz {self.X} {self.Y} {self.Z}){endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        return ['xyz', self.X, self.Y, self.Z]
 
 
 @dataclass
@@ -202,15 +205,17 @@ class ColorRGBA():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
+    def _to_sexpr_raw(self):
         if self.precision is not None:
             alpha = f'{self.A:.{self.precision}f}'
         else:
-            alpha = f'{self.A}'
+            alpha = self.A
 
-        return f'{indents}(color {self.R} {self.G} {self.B} {alpha}){endline}'
+        return ['color', self.R, self.G, self.B, alpha]
+
 
 @dataclass
 class Stroke():
@@ -275,12 +280,19 @@ class Stroke():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        color = f' {self.color.to_sexpr()}' if self.color is not None else ''
-        ttype = f' (type {self.type})' if self.type is not None else ''
-        return f'{indents}(stroke (width {format_float(self.width)}){ttype}{color}){endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
+    def _to_sexpr_raw(self):
+        expr = ['stroke', ['width', format_float(self.width)]]
+
+        if self.type is not None:
+            expr.append(['type', self.type])
+
+        if self.color is not None:
+            expr.append(self.color._to_sexpr_raw())
+
+        return expr
 
 
 @dataclass
@@ -365,20 +377,34 @@ class Font():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        face_name, thickness, linespacing, color = '', '', '', ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        if self.face is not None:           face_name = f'(face "{dequote(self.face)}") '
-        if self.thickness is not None:      thickness = f' (thickness {self.thickness})'
-        if self.lineSpacing is not None:    linespacing = f' (line_spacing {self.lineSpacing})'
-        if self.color is not None:          color = f' {self.color.to_sexpr()}'
+    def _to_sexpr_raw(self):
+        expr = ['font']
 
-        bold = f' {format_bool("bold", self.bold)}'
-        italic = f' {format_bool("italic", self.italic)}'
+        if self.face is not None:
+            expr.append(['face', escape_and_quote(self.face)])
 
-        expression = f'{indents}(font {face_name}(size {self.height} {self.width}){color}{thickness}{bold}{italic}{linespacing}){endline}'
-        return expression
+        expr.append(['size', self.height, self.width])
+
+        if self.color is not None:
+            expr.append(self.color._to_sexpr_raw())
+
+        if self.thickness is not None:
+            expr.append(['thickness', self.thickness])
+
+        if self.bold:
+            expr.append(format_bool_raw('bold', self.bold))
+
+        if self.italic:
+            expr.append(format_bool_raw('italic', self.italic))
+
+        if self.lineSpacing is not None:
+            expr.append(['line_spacing', self.lineSpacing])
+
+        return expr
+
 
 @dataclass
 class Justify():
@@ -436,22 +462,28 @@ class Justify():
         Returns:
             - str: S-Expression of this object or an empty string (depending on given indentation
               and newline settings) if no justification is given. This will cause the text to be
-              horizontally and vertically aligend
+              horizontally and vertically aligned
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        if self.horizontally is None and self.vertically is None and self.mirror == False:
-            return f'{indents}{endline}'
+    def _to_sexpr_raw(self):
+        if self.horizontally is None and self.vertically is None and not self.mirror:
+            return []
 
-        horizontally, vertically, mirror = '', '', ''
+        expr = ['justify']
 
-        if self.horizontally is not None: horizontally = f' {self.horizontally}'
-        if self.vertically is not None: vertically = f' {self.vertically}'
-        if self.mirror: mirror = f' mirror'
+        if self.horizontally is not None:
+            expr.append(self.horizontally)
 
-        expression = f'{indents}(justify{horizontally}{vertically}{mirror}){endline}'
-        return expression
+        if self.vertically is not None:
+            expr.append(self.vertically)
+
+        if self.mirror:
+            expr.append('mirror')
+
+        return expr
+
 
 @dataclass
 class Effects():
@@ -518,15 +550,23 @@ class Effects():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        justify = f' {self.justify.to_sexpr()}' if self.justify.to_sexpr() != '' else ''
-        hide = f' {format_bool("hide", self.hide)}'
-        href = f' (href "{dequote(self.href)}")' if self.href is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['effects']
+        expr.append(self.font._to_sexpr_raw())
 
-        expression =  f'{indents}(effects {self.font.to_sexpr()}{justify}{href}{hide}){endline}'
-        return expression
+        justify_raw = self.justify._to_sexpr_raw()
+        if len(justify_raw) > 0:
+            expr.append(justify_raw)
+
+        if self.href is not None:
+            expr.append(['href', dequote(self.href)])
+
+        expr.append(format_bool_raw("hide", self.hide))
+
+        return expr
 
 
 @dataclass
@@ -575,10 +615,12 @@ class Net():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(net {self.number} "{dequote(self.name)}"){endline}'
+    def _to_sexpr_raw(self):
+        return ['net', self.number, escape_and_quote(self.name)]
+
 
 @dataclass
 class Group():
@@ -644,18 +686,15 @@ class Group():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(group "{dequote(self.name)}" (uuid "{self.id}"){locked}\n'
-        expression += f'{indents}(members\n'
-        for member in self.members:
-            expression += f' "{member}"'
+    def _to_sexpr_raw(self):
+        expr = ['group', escape_and_quote(self.name), ['uuid', escape_and_quote(self.id)]]
+        expr.append(format_bool_raw("locked", self.locked))
+        expr.append(['members'] + [quote(member) for member in self.members])
+        return expr
 
-        expression += f')\n'
-        expression += f'{indents}){endline}'
-        return expression
 
 @dataclass
 class PageSettings():
@@ -730,17 +769,22 @@ class PageSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        width, height = '', ''
-        portrait = ' portrait' if self.portrait else ''
+    def _to_sexpr_raw(self):
+        expr = ['paper', escape_and_quote(self.paperSize)]
+
         if self.paperSize == 'User':
             if self.width is None or self.height is None:
                 raise Exception("Page size set to 'User' but width or height not specified")
-            width = f' {self.width}'
-            height = f' {self.height}'
-        return f'{indents}(paper "{dequote(self.paperSize)}"{width}{height}{portrait}){endline}'
+            expr.extend([self.width, self.height])
+
+        if self.portrait:
+            expr.append('portrait')
+
+        return expr
+
 
 @dataclass
 class TitleBlock():
@@ -810,26 +854,29 @@ class TitleBlock():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(title_block\n'
+    def _to_sexpr_raw(self):
+        expr = ['title_block']
+
         if self.title is not None:
-            expression += f'{indents}  (title "{dequote(self.title)}")\n'
+            expr.append(['title', escape_and_quote(self.title)])
 
         if self.date is not None:
-            expression += f'{indents}  (date "{dequote(self.date)}")\n'
+            expr.append(['date', escape_and_quote(self.date)])
 
         if self.revision is not None:
-            expression += f'{indents}  (rev "{dequote(self.revision)}")\n'
+            expr.append(['rev', escape_and_quote(self.revision)])
 
         if self.company is not None:
-            expression += f'{indents}  (company "{dequote(self.company)}")\n'
+            expr.append(['company', escape_and_quote(self.company)])
 
         for number, comment in self.comments.items():
-            expression += f'{indents}  (comment {number} "{dequote(comment)}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['comment', number, escape_and_quote(comment)])
+
+        return expr
+
 
 @dataclass
 class Property():
@@ -919,28 +966,37 @@ class Property():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        id = f' (id {self.id})' if self.id is not None else ''
-        sn = f' ({format_bool("show_name", self.showName, compact=True)})' if self.showName else ''
-        dna = f' ({format_bool("do_not_autoplace", self.do_not_autoplace, compact=True)})' if self.do_not_autoplace else ''
+    def _to_sexpr_raw(self):
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
 
-        if self.key in ['Datasheet', 'Sim.Library'] and len(self.value) > 0 and self.value not in ['.', '~'] and not is_url(self.value):
-            # KiCad stores them like this, maybe we should just follow even though we do not necessarily agree. Right, KiCad?
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+
+        if (self.key in ['Datasheet', 'Sim.Library'] and len(self.value) > 0
+                and self.value not in ['.','~'] and not is_url(self.value)):
             value = str(PureWindowsPath(self.value)).replace("\\", "\\\\")
         else:
             value = self.value
 
-        expression =  f'{indents}(property "{dequote(self.key)}" "{dequote(value)}"{id} (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){sn}{dna}'
-        if self.effects is not None:
-            expression += f'\n{self.effects.to_sexpr(indent+2)}'
-            expression += f'{indents}){endline}'
-        else:
-            expression += f'){endline}'
+        expr = ['property', escape_and_quote(self.key), escape_and_quote(value), pos]
 
-        return expression
+        if self.id is not None:
+            expr.append(['id', self.id])
+
+        if self.showName:
+            expr.append(format_bool_raw('show_name', self.showName))
+
+        if self.do_not_autoplace:
+            expr.append(format_bool_raw('do_not_autoplace', self.do_not_autoplace))
+
+        if self.effects is not None:
+            expr.append(self.effects._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class RenderCachePolygon():
@@ -993,23 +1049,16 @@ class RenderCachePolygon():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(polygon\n'
-        expression += f'{indents}  (pts'
-
+    def _to_sexpr_raw(self):
+        pts_expr = []
         for i, point in enumerate(self.pts):
-            if i % 4 == 0:
-                expression += f'\n'
-            expression += f'{indents}    '
-            expression += f'(xy {format_float(point.X)} {format_float(point.Y)})'
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
 
-        # NOTE: This expects the length of the points array to be a multiple of four to get the
-        #       formatting right.
-        expression += f'\n{indents}  )\n'
-        expression += f'{indents}){endline}'
-        return expression
+        return ['polygon', ['pts'] + pts_expr]
+
 
 @dataclass
 class RenderCache():
@@ -1071,14 +1120,17 @@ class RenderCache():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(render_cache "{dequote(self.text)}" {self.id}\n'
+    def _to_sexpr_raw(self):
+        expr = ['render_cache', escape_and_quote(self.text), self.id]
+
         for poly in self.polygons:
-            expression += poly.to_sexpr()
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(poly._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class Fill():
@@ -1141,12 +1193,17 @@ class Fill():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        color = f' {self.color.to_sexpr()}' if self.color is not None else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(fill (type {self.type}){color}){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        expr = ['fill', ['type', self.type]]
+
+        if self.color is not None:
+            expr.append(self.color._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class Image():
@@ -1217,21 +1274,25 @@ class Image():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        scale = f' (scale {self.scale})' if self.scale is not None else ''
-        layer = f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['image', ['at', format_float(self.position.X), format_float(self.position.Y)]]
 
-        expression =  f'{indents}(image (at {self.position.X} {self.position.Y}){layer}{scale}\n'
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.scale is not None:
+            expr.append(['scale', self.scale])
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
-        expression += f'{indents}  (data\n'
-        for b64part in self.data:
-            expression += f'{indents}    {b64part}\n'
-        expression += f'{indents}  )\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        expr.append(['data'] + [quote(b64part) for b64part in self.data])
+
+        return expr
+
 
 @dataclass
 class EmbeddedFile():
@@ -1303,21 +1364,19 @@ class EmbeddedFile():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(file\n'
-        expression += f'{indents}(name "{self.name}")\n'
-        expression += f'{indents}(type {self.type})\n'
+    def _to_sexpr_raw(self):
+        expr = ['file']
 
-        expression += f'{indents}(data\n'
-        for b64part in self.data:
-            expression += f'{indents}{b64part}\n'
-        expression += f'{indents})\n'
+        expr.append(['name', quote(self.name)])
+        expr.append(['type', self.type])
+        expr.append(['data'] + self.data)
+        expr.append(['checksum', quote(self.checksum)])
 
-        expression += f'{indents}(checksum "{self.checksum}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+
 
 @dataclass
 class ProjectInstance(ABC):

--- a/src/kiutils/items/dimensions.py
+++ b/src/kiutils/items/dimensions.py
@@ -22,8 +22,9 @@ from typing import Optional, List
 from kiutils.items.common import Position
 from kiutils.items.gritems import GrText
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.string_utils import dequote
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.string_utils import *
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class DimensionFormat():
@@ -110,16 +111,29 @@ class DimensionFormat():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        prefix = f' (prefix "{dequote(self.prefix)}")' if self.prefix is not None else ''
-        suffix = f' (suffix "{dequote(self.suffix)}")' if self.suffix is not None else ''
-        overwrite_val = f' (override_value "{dequote(self.overrideValue)}")' if self.overrideValue is not None else ''
-        suppress_zeroes = f' {format_bool("suppress_zeroes", self.suppressZeroes)}'
+    def _to_sexpr_raw(self):
+        expr = ['format']
 
-        expression =  f'{indents}(format{prefix}{suffix} (units {self.units}) (units_format {self.unitsFormat}) (precision {self.precision}){overwrite_val}{suppress_zeroes}){endline}'
-        return expression
+        if self.prefix is not None:
+            expr.append(['prefix', escape_and_quote(self.prefix)])
+
+        if self.suffix is not None:
+            expr.append(['suffix', escape_and_quote(self.suffix)])
+
+        expr.append(['units', self.units])
+        expr.append(['units_format', self.unitsFormat])
+        expr.append(['precision', self.precision])
+
+        if self.overrideValue is not None:
+            expr.append(['override_value', escape_and_quote(self.overrideValue)])
+
+        expr.append(format_bool_raw('suppress_zeroes', self.suppressZeroes))
+
+        return expr
+
 
 @dataclass
 class DimensionStyle():
@@ -219,17 +233,32 @@ class DimensionStyle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        extension_height = f' (extension_height {self.extensionHeight})' if self.extensionHeight is not None else ''
-        text_frame = f' (text_frame {self.textFrame})' if self.textFrame is not None else ''
-        extension_offset = f' (extension_offset {self.extensionOffset})' if self.extensionOffset is not None else ''
-        keep_aligned = f' {format_bool("keep_text_aligned", self.keepTextAligned)}'
-        arrow_direction = f' (arrow_direction {self.arrow_direction})' if self.arrow_direction is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['style']
 
-        expression =  f'{indents}(style (thickness {self.thickness}) (arrow_length {self.arrowLength}) (text_position_mode {self.textPositionMode}){arrow_direction}{extension_height}{text_frame}{extension_offset}{keep_aligned}){endline}'
-        return expression
+        expr.append(['thickness', self.thickness])
+        expr.append(['arrow_length', self.arrowLength])
+        expr.append(['text_position_mode', self.textPositionMode])
+
+        if self.arrow_direction is not None:
+            expr.append(['arrow_direction', self.arrow_direction])
+
+        if self.extensionHeight is not None:
+            expr.append(['extension_height', self.extensionHeight])
+
+        if self.textFrame is not None:
+            expr.append(['text_frame', self.textFrame])
+
+        if self.extensionOffset is not None:
+            expr.append(['extension_offset', self.extensionOffset])
+
+        expr.append(format_bool_raw('keep_text_aligned', self.keepTextAligned))
+
+        return expr
+
 
 @dataclass
 class Dimension():
@@ -333,28 +362,43 @@ class Dimension():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        points = ''
-        for point in self.pts:
-            points = f'{points} (xy {format_float(point.X)} {format_float(point.Y)})'
-        if len(points) == 0:
+    def _to_sexpr_raw(self):
+        if not self.pts:
             raise Exception("Number of points must not be zero")
 
-        locked = f' {format_bool("locked", self.locked)}'
-        expression =   f'{indents}(dimension (type {self.type}) (layer "{self.layer}") (uuid "{self.tstamp}"){locked}\n'
-        expression +=  f'{indents}  (pts{points})\n'
+        expr = [
+            'dimension',
+            ['type', self.type],
+            ['layer', quote(self.layer)],
+            ['uuid', quote(self.tstamp)],
+        ]
+
+        expr.append(format_bool_raw('locked', self.locked))
+
+        # Points
+        pts_expr = ['pts']
+        for point in self.pts:
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts_expr)
+
         if self.height is not None:
-            expression +=  f'{indents}  (height {self.height})\n'
+            expr.append(['height', self.height])
+
         if self.orientation is not None:
-            expression +=  f'{indents}  (orientation {self.orientation})\n'
+            expr.append(['orientation', self.orientation])
+
         if self.leaderLength is not None:
-            expression +=  f'{indents}  (leader_length {self.leaderLength})\n'
+            expr.append(['leader_length', self.leaderLength])
+
         if self.format is not None:
-            expression += self.format.to_sexpr(indent+2)
-        expression += self.style.to_sexpr(indent+2)
+            expr.append(self.format._to_sexpr_raw())
+
+        expr.append(self.style._to_sexpr_raw())
+
         if self.grText is not None:
-            expression += self.grText.to_sexpr(indent+2)
-        expression +=  f'{indents}){endline}'
-        return expression
+            expr.append(self.grText._to_sexpr_raw())
+
+        return expr

--- a/src/kiutils/items/fpitems.py
+++ b/src/kiutils/items/fpitems.py
@@ -135,16 +135,12 @@ class FpText():
         pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
         if self.position.angle is not None:
             pos.append(format_float(self.position.angle))
-
-        unlocked_pos = format_bool_raw('unlocked', self.position.unlocked)
-        if unlocked_pos:
-            pos.append(unlocked_pos)
-
+        if self.position.unlocked:
+            pos.append(format_bool_raw('unlocked', self.position.unlocked))
         expr.append(pos)
 
-        unlocked = format_bool_raw('unlocked', self.unlocked)
-        if unlocked:
-            expr.append(unlocked)
+        if self.unlocked:
+            expr.append(format_bool_raw('unlocked', self.unlocked))
 
         if self.layer is not None:
             layer_expr = ['layer', escape_and_quote(self.layer)]
@@ -152,9 +148,8 @@ class FpText():
                 layer_expr.append('knockout')
             expr.append(layer_expr)
 
-        hide = format_bool_raw('hide', self.hide)
-        if hide:
-            expr.append(hide)
+        if self.hide:
+            expr.append(format_bool_raw('hide', self.hide))
 
         if self.tstamp is not None:
             expr.append(['uuid', quote(self.tstamp)])
@@ -253,10 +248,11 @@ class FpLine():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['fp_line']
-
-        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
-        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+        expr = [
+            'fp_line',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         if self.width is not None:
             expr.append(['width', self.width])
@@ -361,10 +357,11 @@ class FpRect():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['fp_rect']
-
-        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
-        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+        expr = [
+            'fp_rect',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         if self.width is not None:
             expr.append(['width', self.width])
@@ -638,10 +635,11 @@ class FpCircle():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['fp_circle']
-
-        expr.append(['center', format_float(self.center.X), format_float(self.center.Y)])
-        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+        expr = [
+            'fp_circle',
+            ['center', format_float(self.center.X), format_float(self.center.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         if self.width is not None:
             expr.append(['width', self.width])
@@ -748,11 +746,12 @@ class FpArc():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['fp_arc']
-
-        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
-        expr.append(['mid', format_float(self.mid.X), format_float(self.mid.Y)])
-        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+        expr = [
+            'fp_arc',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         if self.width is not None:
             expr.append(['width', self.width])
@@ -973,8 +972,8 @@ class FpCurve():
         pts_expr = ['pts']
         for point in self.coordinates:
             pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
-
         expr.append(pts_expr)
+
         expr.append(['layer', escape_and_quote(self.layer)])
 
         if self.width is not None:
@@ -1078,17 +1077,19 @@ class FpProperty:
         expr = ['property', prop_type, escape_and_quote(self.text)]
 
         if self.position is not None:
-            pos = self.position
-            expr.append(['at', format_float(pos.X), format_float(pos.Y)] + ([pos.angle] if pos.angle is not None else []))
+            pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+            if self.position.angle is not None:
+                pos.append(format_float(self.position.angle))
+            expr.append(pos)
 
         if self.unlocked is not None:
             expr.append(['unlocked', self.unlocked])
 
         if self.layer is not None:
-            layer_str = escape_and_quote(self.layer)
+            layer_expr = ['layer', escape_and_quote(self.layer)]
             if self.ko:
-                layer_str = f"{layer_str} knockout"
-            expr.append(['layer', layer_str])
+                layer_expr.append("knockout")
+            expr.append(layer_expr)
 
         if self.hide is not None:
             expr.append(['hide', self.hide])

--- a/src/kiutils/items/fpitems.py
+++ b/src/kiutils/items/fpitems.py
@@ -21,9 +21,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 
 from kiutils.items.common import RenderCache, Stroke, Position, Effects
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
 from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.sexpr import sexp_to_string
 
 # FIXME: Several classes have a ``stroke`` member. This feature will be introduced in KiCad 7 and
 #        has yet to be tested here.

--- a/src/kiutils/items/fpitems.py
+++ b/src/kiutils/items/fpitems.py
@@ -23,7 +23,7 @@ from typing import Optional, List
 from kiutils.items.common import RenderCache, Stroke, Position, Effects
 from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
 from kiutils.utils.sexpr import sexp_to_string
 
 # FIXME: Several classes have a ``stroke`` member. This feature will be introduced in KiCad 7 and
@@ -126,24 +126,46 @@ class FpText():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        hide = f' {format_bool("hide", self.hide)}'
-        unlocked = f' {format_bool("unlocked", self.unlocked)}'
-        unlocked_pos = f' {format_bool("unlocked", self.position.unlocked)}'
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        ko = ' knockout' if self.knockout else ''
+    def _to_sexpr_raw(self):
+        expr = ['fp_text', self.type, escape_and_quote(self.text)]
 
-        expression =  (f'{indents}(fp_text {self.type} "{dequote(self.text)}" (at {format_float(self.position.X)} {format_float(self.position.Y)}'
-                       f'{posA}{unlocked_pos}){unlocked} (layer "{dequote(self.layer)}"{ko}){hide}\n')
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+
+        unlocked_pos = format_bool_raw('unlocked', self.position.unlocked)
+        if unlocked_pos:
+            pos.append(unlocked_pos)
+
+        expr.append(pos)
+
+        unlocked = format_bool_raw('unlocked', self.unlocked)
+        if unlocked:
+            expr.append(unlocked)
+
+        if self.layer is not None:
+            layer_expr = ['layer', escape_and_quote(self.layer)]
+            if self.knockout:
+                layer_expr.append('knockout')
+            expr.append(layer_expr)
+
+        hide = format_bool_raw('hide', self.hide)
+        if hide:
+            expr.append(hide)
+
         if self.tstamp is not None:
-            expression += f'{indents}  (uuid "{self.tstamp}")\n'
-        expression += f'{indents}  {self.effects.to_sexpr(indent+2)}'
+            expr.append(['uuid', quote(self.tstamp)])
+
+        expr.append(self.effects._to_sexpr_raw())
+
         if self.renderCache is not None:
-            expression += self.renderCache.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(self.renderCache._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class FpLine():
@@ -227,19 +249,28 @@ class FpLine():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
-        if self.width is not None:
-            width = f' (width {self.width})'
-        elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return (f'{indents}(fp_line(start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)}){width}'
-                f'{locked}(layer "{dequote(self.layer)}"){tstamp}){endline}')
+    def _to_sexpr_raw(self):
+        expr = ['fp_line']
+
+        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
+        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+
+        if self.width is not None:
+            expr.append(['width', self.width])
+        elif self.stroke is not None:
+            expr.append(self.stroke._to_sexpr_raw())
+
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpRect():
@@ -326,22 +357,31 @@ class FpRect():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['fp_rect']
+
+        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
+        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
 
         if self.width is not None:
-            width = f' (width {self.width})'
+            expr.append(['width', self.width])
         elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(fp_rect (start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{fill}{locked} (layer "{dequote(self.layer)}"){tstamp}){endline}')
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpTextBox():
@@ -464,6 +504,10 @@ class FpTextBox():
         Returns:
             - str: S-Expression of this object
         """
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
         if self.angle is not None and self.angle not in [0.0, 90.0, 180.0, 270.0]:
             if len(self.pts) != 4:
                 raise Exception("None-cardinal angles must have exactly four corner points defined")
@@ -471,30 +515,39 @@ class FpTextBox():
             if self.start is None or self.end is None:
                 raise Exception("No angle or a cardinal angle needs a start and end token defined")
 
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        expr = ['fp_text_box', format_bool_raw('locked', self.locked), escape_and_quote(self.text)]
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        angle = f'(angle {self.angle}) ' if self.angle is not None else ''
-        start = f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) ' if self.start is not None else ''
-        end = f'(end {format_float(self.end.X)} {format_float(self.end.Y)}) ' if self.end is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
-
-        expression = f'{indents}(fp_text_box{locked} "{dequote(self.text)}"\n'
         if len(self.pts) == 4:
-            expression += f'{indents}  (pts\n'
-            expression += (f'{indents}    (xy {format_float(self.pts[0].X)} {format_float(self.pts[0].Y)}) (xy {format_float(self.pts[1].X)} {format_float(self.pts[1].Y)})'
-                           f'(xy {format_float(self.pts[2].X)} {format_float(self.pts[2].Y)}) (xy {format_float(self.pts[3].X)} {format_float(self.pts[3].Y)})\n')
-            expression += f'{indents}  )\n'
-        expression += f'{indents}  {start}{end}{angle}(layer "{dequote(self.layer)}"){tstamp}\n'
+            pts_expr = ['pts']
+            for pt in self.pts:
+                pts_expr.append(['xy', format_float(pt.X), format_float(pt.Y)])
+            expr.append(pts_expr)
+
+        if self.start is not None:
+            expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
+
+        if self.end is not None:
+            expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+
+        if self.angle is not None:
+            expr.append(['angle', self.angle])
+
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
         if self.effects is not None:
-            expression += self.effects.to_sexpr(indent+2)
+            expr.append(self.effects._to_sexpr_raw())
+
         if self.stroke is not None:
-            expression += self.stroke.to_sexpr(indent+2)
+            expr.append(self.stroke._to_sexpr_raw())
+
         if self.renderCache is not None:
-            expression += self.renderCache.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(self.renderCache._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class FpCircle():
@@ -581,22 +634,31 @@ class FpCircle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['fp_circle']
+
+        expr.append(['center', format_float(self.center.X), format_float(self.center.Y)])
+        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
 
         if self.width is not None:
-            width = f' (width {self.width})'
+            expr.append(['width', self.width])
         elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(fp_circle (center {format_float(self.center.X)} {format_float(self.center.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{fill}{locked} (layer "{dequote(self.layer)}"){tstamp}){endline}')
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpArc():
@@ -682,22 +744,29 @@ class FpArc():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+    def _to_sexpr_raw(self):
+        expr = ['fp_arc']
+
+        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
+        expr.append(['mid', format_float(self.mid.X), format_float(self.mid.Y)])
+        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
 
         if self.width is not None:
-            width = f' (width {self.width})'
+            expr.append(['width', self.width])
         elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(fp_arc'
-                f' (start {format_float(self.start.X)} {format_float(self.start.Y)}) (mid {format_float(self.mid.X)} {format_float(self.mid.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{locked} (layer "{dequote(self.layer)}"){tstamp}){endline}')
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpPoly():
@@ -783,27 +852,35 @@ class FpPoly():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
+    def _to_sexpr_raw(self):
+        if len(self.coordinates) == 0:
+            return []
+
+        expr = ['fp_poly']
+        pts_expr = ['pts']
+        for point in self.coordinates:
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts_expr)
 
         if self.width is not None:
-            width = f' (width {self.width})'
+            expr.append(['width', self.width])
         elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+            expr.append(self.stroke._to_sexpr_raw())
 
-        expression = f'{indents}(fp_poly (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  ){width}{fill}{locked} (layer "{dequote(self.layer)}"){tstamp}){endline}'
-        return expression
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+        expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpCurve():
@@ -884,26 +961,34 @@ class FpCurve():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+    def _to_sexpr_raw(self):
+        if len(self.coordinates) == 0:
+            return []
+
+        expr = ['fp_curve']
+
+        pts_expr = ['pts']
+        for point in self.coordinates:
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
+
+        expr.append(pts_expr)
+        expr.append(['layer', escape_and_quote(self.layer)])
 
         if self.width is not None:
-            width = f' (width {self.width})'
+            expr.append(['width', self.width])
         elif self.stroke is not None:
-            width = f' {self.stroke.to_sexpr(indent=0, newline=False)}'
-        else:
-            width = ''
+            expr.append(self.stroke._to_sexpr_raw())
 
-        expression = f'{indents}(fp_curve (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}  (xy {point.X} {point.Y})\n'
-        expression += f'{indents}) (layer "{dequote(self.layer)}"){width}{locked}{tstamp}){endline}'
-        return expression
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class FpProperty:
@@ -982,36 +1067,40 @@ class FpProperty:
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        prop_str = f'"{dequote(self.type)}"' if self.type != "ki_fp_filters" else dequote(self.type)
-        expression = f'{indents}(property {prop_str} "{dequote(self.text)}"\n'
+    def _to_sexpr_raw(self):
+        prop_type = dequote(self.type)
+        if self.type != "ki_fp_filters":
+            prop_type = quote(prop_type)
+
+        expr = ['property', prop_type, escape_and_quote(self.text)]
 
         if self.position is not None:
             pos = self.position
-            pos_angle = f' {pos.angle}' if pos.angle is not None else ''
-            expression += f'{indents} (at {format_float(pos.X)} {format_float(pos.Y)}{pos_angle}){endline}'
+            expr.append(['at', format_float(pos.X), format_float(pos.Y)] + ([pos.angle] if pos.angle is not None else []))
 
         if self.unlocked is not None:
-            expression += f'{indents} (unlocked yes){endline}'
+            expr.append(['unlocked', self.unlocked])
 
         if self.layer is not None:
-            layer = self.layer
-            ko = ' knockout' if self.ko else ''
-            expression += f'{indents} (layer "{dequote(layer)}"{ko}){endline}'
+            layer_str = escape_and_quote(self.layer)
+            if self.ko:
+                layer_str = f"{layer_str} knockout"
+            expr.append(['layer', layer_str])
 
         if self.hide is not None:
-            expression += f'{indents} (hide yes){endline}'
+            expr.append(['hide', self.hide])
 
         if self.tstamp is not None:
-            expression += f'{indents} (uuid "{dequote(self.tstamp)}"){endline}'
+            expr.append(['uuid', quote(self.tstamp)])
 
         if self.effects is not None:
-            expression += f'{indents} {self.effects.to_sexpr()}'
+            expr.append(self.effects._to_sexpr_raw())
 
         if self.render_cache is not None:
-            expression += f'{indents} {self.render_cache.to_sexpr()}'
+            expr.append(self.render_cache._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+

--- a/src/kiutils/items/gritems.py
+++ b/src/kiutils/items/gritems.py
@@ -21,9 +21,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 
 from kiutils.items.common import Effects, Position, RenderCache, Stroke
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class GrText():
@@ -112,21 +113,36 @@ class GrText():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        ko = ' knockout' if self.knockout else ''
-        posA = f' {self.position.angle}' if self.position.angle is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}"{ko})' if self.layer is not None else ''
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+    def _to_sexpr_raw(self):
+        expr = ['gr_text', escape_and_quote(self.text)]
 
-        expression =  f'{indents}(gr_text "{dequote(self.text)}"{locked} (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){layer}{tstamp}\n'
-        expression += f'{indents}  {self.effects.to_sexpr()}'
+        expr.append(format_bool_raw('locked', self.locked))
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(self.position.angle)
+
+        expr.append(pos)
+
+        layer = ['layer', escape_and_quote(self.layer)] if self.layer is not None else None
+        if layer and self.knockout:
+            layer.append('knockout')
+
+        if layer:
+            expr.append(layer)
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        expr.append(self.effects._to_sexpr_raw())
+
         if self.renderCache is not None:
-            expression += self.renderCache.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(self.renderCache._to_sexpr_raw())
+
+        return expr
 
 @dataclass
 class GrTextBox():
@@ -188,7 +204,8 @@ class GrTextBox():
     def from_sexpr(cls, exp: list) -> GrTextBox:
         raise Exception('We never dealt with this before.'
                         'Most definitely there were changes introduced between Kicad 7 and 9.'
-                        'If you know what you are doing, proceed to verify/fix and remove the exception.')
+                        'If you know what you are doing, proceed to verify/fix and remove the exception,'
+                        'or contact the maintainer.')
 
         # """Convert the given S-Expression into a GrTextBox object
         #
@@ -360,27 +377,35 @@ class GrLine():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
-        angle = f' (angle {self.angle}' if self.angle is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'gr_line',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
-        width = ''
+        if self.angle is not None: expr.append(['angle', self.angle])
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(gr_line '
-                f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{angle}{width}{locked}{layer}{tstamp}){endline}')
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrRect():
@@ -461,27 +486,37 @@ class GrRect():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'gr_rect',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
-        width = ''
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(gr_rect '
-                f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{fill}{locked}{layer}{tstamp}){endline}')
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrCircle():
@@ -562,27 +597,37 @@ class GrCircle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'gr_circle',
+            ['center', format_float(self.center.X), format_float(self.center.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
-        width = ''
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(gr_circle '
-                f'(center {format_float(self.center.X)} {format_float(self.center.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{fill}{locked}{layer}{tstamp}){endline}')
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrArc():
@@ -663,28 +708,35 @@ class GrArc():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'gr_arc',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
-        width = ''
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        return (f'{indents}(gr_arc '
-                f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) '
-                f'(mid {format_float(self.mid.X)} {format_float(self.mid.Y)}) '
-                f'(end {format_float(self.end.X)} {format_float(self.end.Y)})'
-                f'{width}{locked}{layer}{tstamp}){endline}')
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrPoly():
@@ -759,44 +811,50 @@ class GrPoly():
 
         Args:
             - indent (int): Number of whitespaces used to indent the output. Defaults to 2.
-            - newline (bool): Adds a newline to the end of the output. Defaults to True.
-            - pts_newline (bool): Adds a newline for the ``(pts ..)`` token as KiCad treats
-                                  this different in Board files than Footprint files. Defaults to 
-                                  False.
+            - newline (bool): Adds a newline for the ``(pts ..)`` token as KiCad treats
+                              this different in Board files than Footprint files. Defaults to
+                              False.
+            - pts_newline (bool): Adds a newline for the ``(pts ..)`` token. Defaults to False.
 
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
         if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+            return ''
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
-        fill = f' (fill {self.fill})' if self.fill is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        if pts_newline:
-            expression =  f'{indents}(gr_poly\n'
-            expression += f'{indents}  (pts\n'
-        else:
-            expression =  f'{indents}(gr_poly (pts\n'
+    def _to_sexpr_raw(self):
+        expr = ['gr_poly']
 
-        width = ''
+        pts = ['pts']
+        for point in self.coordinates:
+            pts.append(['xy', format_float(point.X), format_float(point.Y)])
+
+        expr.append(pts)
+
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        for point in self.coordinates:
-            expression += f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  ){width}{fill}{locked}{layer}{tstamp}){endline}'
-        return expression
+        if self.fill is not None:
+            expr.append(['fill', self.fill])
+
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrCurve():
@@ -870,30 +928,39 @@ class GrCurve():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
         if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+            return ''
 
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        layer =  f' (layer "{dequote(self.layer)}")' if self.layer is not None else ''
-        locked = f' {format_bool("locked", self.locked)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        width = ''
+    def _to_sexpr_raw(self):
+        expr = ['gr_curve']
+
+        pts = ['pts']
+        for point in self.coordinates:
+            pts.append(['xy', format_float(point.X), format_float(point.Y)])
+
+        expr.append(pts)
+
         if self.width is not None:
-            width = f' (width {format_float(self.width)})'
-            # Little sanity check
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
+            expr.append(['width', format_float(self.width)])
 
         if self.stroke is not None:
-            width = f' {self.stroke.to_sexpr()}'
+            expr.append(self.stroke._to_sexpr_raw())
 
-        expression = f'{indents}(gr_curve (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}  (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}){width}{locked}{layer}{tstamp}){endline}'
-        return expression
+        expr.append(format_bool_raw('locked', self.locked))
+
+        if self.layer is not None:
+            expr.append(['layer', escape_and_quote(self.layer)])
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        return expr
+
 
 @dataclass
 class GrStroke():
@@ -934,8 +1001,7 @@ class GrStroke():
         return object
 
     def to_sexpr(self, indent: int = 0, newline: bool = False) -> str:
-        """Generate the S-Expression representing this object. When no coordinates are set
-        in the curve, the resulting S-Expression will be left empty.
+        """Generate the S-Expression representing this object.
 
         Args:
             - indent (int): Number of whitespaces used to indent the output. Defaults to 0.
@@ -944,7 +1010,8 @@ class GrStroke():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(stroke (width {format_float(self.width)}) (type {self.type})){endline}'
+    def _to_sexpr_raw(self):
+        return ['stroke', ['width', format_float(self.width)], ['type', self.type]]

--- a/src/kiutils/items/gritems.py
+++ b/src/kiutils/items/gritems.py
@@ -123,14 +123,12 @@ class GrText():
 
         pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
         if self.position.angle is not None:
-            pos.append(self.position.angle)
-
+            pos.append(format_float(self.position.angle))
         expr.append(pos)
 
         layer = ['layer', escape_and_quote(self.layer)] if self.layer is not None else None
         if layer and self.knockout:
             layer.append('knockout')
-
         if layer:
             expr.append(layer)
 
@@ -387,7 +385,7 @@ class GrLine():
             ['end', format_float(self.end.X), format_float(self.end.Y)],
         ]
 
-        if self.angle is not None: expr.append(['angle', self.angle])
+        if self.angle is not None: expr.append(['angle', format_float(self.angle)])
         if self.width is not None:
             if self.stroke is not None:
                 raise Exception("I didn't expect both stroke and width. Something is off...")
@@ -831,7 +829,6 @@ class GrPoly():
         pts = ['pts']
         for point in self.coordinates:
             pts.append(['xy', format_float(point.X), format_float(point.Y)])
-
         expr.append(pts)
 
         if self.width is not None:
@@ -940,7 +937,6 @@ class GrCurve():
         pts = ['pts']
         for point in self.coordinates:
             pts.append(['xy', format_float(point.X), format_float(point.Y)])
-
         expr.append(pts)
 
         if self.width is not None:

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -721,6 +721,8 @@ class LocalLabel():
     """The ``fields_autoplaced`` is a flag that indicates that any PROPERTIES associated
     with the global label have been place automatically"""
 
+    properties: list[Property] = field(default_factory=list)
+
     @classmethod
     def from_sexpr(cls, exp: list) -> LocalLabel:
         """Convert the given S-Expresstion into a LocalLabel object
@@ -750,7 +752,7 @@ class LocalLabel():
             elif item[0] == 'at': object.position = Position().from_sexpr(item)
             elif item[0] == 'effects': object.effects = Effects().from_sexpr(item)
             elif item[0] == 'uuid': object.uuid = item[1]
-            elif item[0] == 'property': continue #Ignore this please
+            elif item[0] == 'property': object.properties.append(Property().from_sexpr(item))
             else:
                 raise ValueError(f"Unrecognized property key: {item[0]}. Exp: {exp}")
             
@@ -781,6 +783,9 @@ class LocalLabel():
         expr.append(self.effects._to_sexpr_raw())
         if self.uuid is not None:
             expr.append(['uuid', quote(self.uuid)])
+
+        for prop in self.properties:
+            expr.append(prop._to_sexpr_raw())
 
         return expr
 
@@ -916,6 +921,8 @@ class HierarchicalLabel():
     """The ``fields_autoplaced`` is a flag that indicates that any PROPERTIES associated
     with the global label have been place automatically"""
 
+    properties: list[Property] = field(default_factory=list)
+
     @classmethod
     def from_sexpr(cls, exp: list) -> HierarchicalLabel:
         """Convert the given S-Expresstion into a HierarchicalLabel object
@@ -946,7 +953,7 @@ class HierarchicalLabel():
             elif item[0] == 'effects': object.effects = Effects().from_sexpr(item)
             elif item[0] == 'shape': object.shape = item[1]
             elif item[0] == 'uuid': object.uuid = item[1]
-            elif item[0] == 'property': continue #Ignore this please
+            elif item[0] == 'property': object.properties.append(Property().from_sexpr(item))
             else:
                 raise ValueError(f"Unrecognized property key: {item[0]}. Full expression: {item}")
 
@@ -976,11 +983,12 @@ class HierarchicalLabel():
         expr.append(pos)
 
         expr.append(format_bool_raw('fields_autoplaced', self.fieldsAutoplaced))
-
+        expr.append(self.effects._to_sexpr_raw())
         if self.uuid is not None:
             expr.append(['uuid', quote(self.uuid)])
 
-        expr.append(self.effects._to_sexpr_raw())
+        for prop in self.properties:
+            expr.append(prop._to_sexpr_raw())
 
         return expr
 
@@ -1685,10 +1693,11 @@ class HierarchicalSheet():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['sheet']
-
-        expr.append(['at', format_float(self.position.X), format_float(self.position.Y)])
-        expr.append(['size', format_float(self.width), format_float(self.height)])
+        expr = [
+            'sheet',
+            ['at', format_float(self.position.X), format_float(self.position.Y)],
+            ['size', format_float(self.width), format_float(self.height)],
+        ]
 
         if self.exclude_from_sim is not None:
             expr.append(['exclude_from_sim', self.exclude_from_sim])
@@ -1861,14 +1870,13 @@ class SymbolInstance():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['path', escape_and_quote(self.path)]
-
-        expr.append(['reference', escape_and_quote(self.reference)])
-        expr.append(['unit', self.unit])
-        expr.append(['value', escape_and_quote(self.value)])
-        expr.append(['footprint', escape_and_quote(self.footprint)])
-
-        return expr
+        return [
+            'path', escape_and_quote(self.path),
+            ['reference', escape_and_quote(self.reference)],
+            ['unit', self.unit],
+            ['value', escape_and_quote(self.value)],
+            ['footprint', escape_and_quote(self.footprint)],
+        ]
 
 
 @dataclass
@@ -1943,9 +1951,11 @@ class Rectangle():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['rectangle',
-                ['start', format_float(self.start.X), format_float(self.start.Y)],
-                ['end', format_float(self.end.X), format_float(self.end.Y)]]
+        expr = [
+            'rectangle',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         expr.append(self.stroke._to_sexpr_raw())
         expr.append(self.fill._to_sexpr_raw())
@@ -2032,10 +2042,12 @@ class Arc():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['arc',
-                ['start', format_float(self.start.X), format_float(self.start.Y)],
-                ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
-                ['end', format_float(self.end.X), format_float(self.end.Y)]]
+        expr = [
+            'arc',
+            ['start', format_float(self.start.X), format_float(self.start.Y)],
+            ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
+            ['end', format_float(self.end.X), format_float(self.end.Y)],
+        ]
 
         expr.append(self.stroke._to_sexpr_raw())
         expr.append(self.fill._to_sexpr_raw())
@@ -2118,9 +2130,11 @@ class Circle():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['circle',
-                ['center', format_float(self.center.X), format_float(self.center.Y)],
-                ['radius', format_float(self.radius)]]
+        expr = [
+            'circle',
+            ['center', format_float(self.center.X), format_float(self.center.Y)],
+            ['radius', format_float(self.radius)],
+        ]
 
         expr.append(self.stroke._to_sexpr_raw())
         expr.append(self.fill._to_sexpr_raw())
@@ -2222,11 +2236,13 @@ class NetclassFlag():
         if self.position.angle is not None:
             pos.append(format_float(self.position.angle))
 
-        expr = ['netclass_flag', escape_and_quote(self.text),
-                ['length', format_float(self.length)],
-                ['shape', self.shape],
-                pos,
-                format_bool_raw('fields_autoplaced', self.fieldsAutoplaced)]
+        expr = [
+            'netclass_flag', escape_and_quote(self.text),
+            ['length', format_float(self.length)],
+            ['shape', self.shape],
+            pos,
+            format_bool_raw('fields_autoplaced', self.fieldsAutoplaced),
+        ]
 
         expr.append(self.effects._to_sexpr_raw())
 

--- a/src/kiutils/items/schitems.py
+++ b/src/kiutils/items/schitems.py
@@ -20,9 +20,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict
 
 from kiutils.items.common import Fill, Position, ColorRGBA, ProjectInstance, Stroke, Effects, Property
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class Junction():
@@ -89,13 +90,20 @@ class Junction():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        uuid = f' (uuid "{self.uuid}")\n' if self.uuid is not None else ''
-        expression =  (f'{indents}(junction '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}) (diameter {format_float(self.diameter)}) '
-                       f'{self.color.to_sexpr()}{uuid}{indents}){endline}')
-        return expression
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['junction']
+
+        expr.append(['at', format_float(self.position.X), format_float(self.position.Y)])
+        expr.append(['diameter', format_float(self.diameter)])
+        expr.append(self.color._to_sexpr_raw())
+        if self.uuid is not None:
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class NoConnect():
@@ -152,11 +160,18 @@ class NoConnect():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        uuid = f' (uuid "{self.uuid}")' if self.uuid is not None else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(no_connect (at {format_float(self.position.X)} {format_float(self.position.Y)}){uuid}){endline}'
+    def _to_sexpr_raw(self):
+        expr = ['no_connect']
+
+        expr.append(['at', format_float(self.position.X), format_float(self.position.Y)])
+        if self.uuid is not None:
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class BusEntry():
@@ -221,15 +236,20 @@ class BusEntry():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(bus_entry (at {format_float(self.position.X)} {format_float(self.position.Y)}) (size {format_float(self.size.X)} {format_float(self.size.Y)})\n'
-        expression += self.stroke.to_sexpr(indent+2)
+    def _to_sexpr_raw(self):
+        expr = ['bus_entry']
+
+        expr.append(['at', format_float(self.position.X), format_float(self.position.Y)])
+        expr.append(['size', format_float(self.size.X), format_float(self.size.Y)])
+        expr.append(self.stroke._to_sexpr_raw())
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class BusAlias():
@@ -289,12 +309,13 @@ class BusAlias():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        members = [f'"{dequote(member)}"' for member in self.members]
-        expression =  f'{indents}(bus_alias "{dequote(self.name)}" (members {" ".join(members)})){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        members_quoted = [escape_and_quote(member) for member in self.members]
+        return ['bus_alias', escape_and_quote(self.name), ['members'] + members_quoted]
+
 
 @dataclass
 class Connection():
@@ -361,19 +382,24 @@ class Connection():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        points = ''
+    def _to_sexpr_raw(self):
+        expr = [self.type]
+
+        pts_expr = ['pts']
         for point in self.points:
-            points += f' (xy {format_float(point.X)} {format_float(point.Y)})'
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts_expr)
 
-        expression =  f'{indents}({self.type} (pts{points})\n'
-        expression += self.stroke.to_sexpr(indent+2)
+        expr.append(self.stroke._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class PolyLine():
@@ -440,23 +466,27 @@ class PolyLine():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        points = ''
+    def _to_sexpr_raw(self):
+        expr = ['polyline']
+
+        pts_expr = ['pts']
         for point in self.points:
-            points += f' (xy {format_float(point.X)} {format_float(point.Y)})'
+            pts_expr.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts_expr)
 
-        expression =  f'{indents}(polyline (pts{points})\n'
-        expression += self.stroke.to_sexpr(indent+2)
+        expr.append(self.stroke._to_sexpr_raw())
+
         if self.fill is not None:
-            expression += self.fill.to_sexpr(indent+2)
+            expr.append(self.fill._to_sexpr_raw())
 
         if self.uuid is not None:
-            expression += f'{indents}(uuid "{self.uuid}")\n'
+            expr.append(['uuid', quote(self.uuid)])
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+
 
 @dataclass
 class Text():
@@ -527,25 +557,26 @@ class Text():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        exclude_from_sim = f' (exclude_from_sim {self.exclude_from_sim})' if self.exclude_from_sim is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['text', escape_and_quote(self.text)]
 
-        expression =  f'{indents}(text "{dequote(self.text)}"{exclude_from_sim}'
+        if self.exclude_from_sim is not None:
+            expr.append(['exclude_from_sim', self.exclude_from_sim])
 
-        # Strings longer or equal than 50 chars have the position in the next line
-        if len(self.text) >= 50:
-            expression += f'\n{indents}  '
-        else:
-            expression += ' '
-        expression += f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA})\n'
-        expression += self.effects.to_sexpr(indent+2)
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(self.effects._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
 
 @dataclass
 class TextBox():
@@ -627,7 +658,7 @@ class TextBox():
 
         return object
 
-    def to_sexpr(self, indent=2, newline=True, table_cell = False) -> str:
+    def to_sexpr(self, indent=2, newline=True, table_cell=False) -> str:
         """Generate the S-Expression representing this object
 
         Args:
@@ -637,26 +668,34 @@ class TextBox():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw(table_cell)
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        exclude_from_sim = f' (exclude_from_sim {self.exclude_from_sim})' if self.exclude_from_sim is not None else ''
-
+    def _to_sexpr_raw(self, table_cell=False):
         target_type = 'table_cell' if table_cell else 'text_box'
+        expr = [target_type, escape_and_quote(self.text)]
 
-        expression =  f'{indents}({target_type} "{dequote(self.text)}"{exclude_from_sim}\n'
-        expression += f'{indents} (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}) (size {format_float(self.size.X)} {format_float(self.size.Y)})\n'
-        expression += f'{indents} (margins {" ".join(map(str, self.margins))}){endline}'
+        if self.exclude_from_sim is not None:
+            expr.append(['exclude_from_sim', self.exclude_from_sim])
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(['size', format_float(self.size.X), format_float(self.size.Y)])
+        expr.append(['margins'] + list(map(str, self.margins)))
         if len(self.span) > 0:
-            expression += f'{indents} (span {self.span[0]} {self.span[1]}){endline}'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += self.effects.to_sexpr(indent+2)
+            expr.append(['span', self.span[0], self.span[1]])
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+        expr.append(self.effects._to_sexpr_raw())
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class LocalLabel():
@@ -727,18 +766,24 @@ class LocalLabel():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        fieldsAutoplaced = f' {format_bool("fields_autoplaced", self.fieldsAutoplaced)}'
+    def _to_sexpr_raw(self):
+        expr = ['label', escape_and_quote(self.text)]
 
-        expression =  f'{indents}(label "{dequote(self.text)}" (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){fieldsAutoplaced}\n'
-        expression += self.effects.to_sexpr(indent+2)
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(format_bool_raw('fields_autoplaced', self.fieldsAutoplaced))
+        expr.append(self.effects._to_sexpr_raw())
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class GlobalLabel():
@@ -818,20 +863,29 @@ class GlobalLabel():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        fa = f' {format_bool("fields_autoplaced", self.fieldsAutoplaced)}'
+    def _to_sexpr_raw(self):
+        expr = ['global_label', escape_and_quote(self.text)]
 
-        expression =  f'{indents}(global_label "{dequote(self.text)}" (shape {self.shape}) (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){fa}\n'
-        expression += self.effects.to_sexpr(indent+2)
+        expr.append(['shape', self.shape])
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(format_bool_raw('fields_autoplaced', self.fieldsAutoplaced))
+        expr.append(self.effects._to_sexpr_raw())
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        for property in self.properties:
-            expression += property.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        for prop in self.properties:
+            expr.append(prop._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class HierarchicalLabel():
@@ -908,19 +962,28 @@ class HierarchicalLabel():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        fieldsAutoplaced = f' {format_bool("fields_autoplaced", self.fieldsAutoplaced)}'
+    def _to_sexpr_raw(self):
+        expr = ['hierarchical_label', escape_and_quote(self.text)]
 
-        expression =  (f'{indents}(hierarchical_label "{dequote(self.text)}" (shape {self.shape}) '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){fieldsAutoplaced}\n')
+        expr.append(['shape', self.shape])
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(format_bool_raw('fields_autoplaced', self.fieldsAutoplaced))
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += self.effects.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        expr.append(self.effects._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SymbolProjectPath():
@@ -986,12 +1049,15 @@ class SymbolProjectPath():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        expression =  f'{indents}(path "{dequote(self.sheetInstancePath)}"\n'
-        expression += f'{indents}  (reference "{dequote(self.reference)}") (unit {self.unit})\n'
-        expression += f'{indents}){endline}'
-        return expression
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['path', escape_and_quote(self.sheetInstancePath)]
+        expr.append(['reference', escape_and_quote(self.reference)])
+        expr.append(['unit', self.unit])
+        return expr
+
 
 @dataclass
 class SymbolProjectInstance(ProjectInstance):
@@ -1050,13 +1116,17 @@ class SymbolProjectInstance(ProjectInstance):
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        expression = f'{indents}(project "{dequote(self.name)}"\n'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['project', escape_and_quote(self.name)]
+
         for path in self.paths:
-            expression += path.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(path._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SchematicSymbol():
@@ -1217,38 +1287,54 @@ class SchematicSymbol():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        mirror = f' (mirror {self.mirror})' if self.mirror is not None else ''
-        exclude_from_sim = f' (exclude_from_sim {self.exclude_from_sim})' if self.exclude_from_sim is not None else ''
-        unit = f' (unit {self.unit})' if self.unit is not None else ''
-        lib_name = f' (lib_name "{dequote(self.libName)}")' if self.libName is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['symbol']
 
-        expression =  (f'{indents}(symbol{lib_name} (lib_id "{dequote(self.libId)}") '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA})'
-                       f'{mirror}{unit}{exclude_from_sim}\n')
+        if self.libName is not None:
+            expr.append(['lib_name', escape_and_quote(self.libName)])
 
-        inBom = format_bool("in_bom", self.inBom, compact=False, yesno=True)
-        onBoard = format_bool("on_board", self.onBoard, compact=False, yesno=True)
-        dnp = format_bool("dnp", self.dnp, compact=False, yesno=True) if self.dnp is not None else ''
-        fa = format_bool("fields_autoplaced", self.fieldsAutoplaced)
-        expression += f'{indents} {inBom} {onBoard} {dnp} {fa}\n'
+        expr.append(['lib_id', escape_and_quote(self.libId)])
+
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        if self.mirror is not None:
+            expr.append(['mirror', self.mirror])
+
+        if self.unit is not None:
+            expr.append(['unit', self.unit])
+
+        if self.exclude_from_sim is not None:
+            expr.append(['exclude_from_sim', self.exclude_from_sim])
+
+        expr.append(format_bool_raw("in_bom", self.inBom, compact=False, yesno=True))
+        expr.append(format_bool_raw("on_board", self.onBoard, compact=False, yesno=True))
+        if self.dnp is not None:
+            expr.append(format_bool_raw("dnp", self.dnp, compact=False, yesno=True))
+        expr.append(format_bool_raw("fields_autoplaced", self.fieldsAutoplaced))
 
         if self.uuid:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
+            expr.append(['uuid', quote(self.uuid)])
+
         for prop in self.properties:
-            expression += prop.to_sexpr(indent+2)
+            expr.append(prop._to_sexpr_raw())
+
         for number, uuid in self.pins.items():
-            expression += f'{indents}  (pin "{dequote(number)}" (uuid "{uuid}"))\n'
+            expr.append(['pin', escape_and_quote(number), ['uuid', quote(uuid)]])
+
         if len(self.instances) != 0:
-            expression += f'{indents}  (instances\n'
+            instances_expr = ['instances']
             for instance in self.instances:
-                expression += instance.to_sexpr(indent+4)
-            expression += f'{indents}  )\n'
-        expression += f'{indents}){endline}'
-        return expression
+                instances_expr.append(instance._to_sexpr_raw())
+            expr.append(instances_expr)
+
+        return expr
+
 
 @dataclass
 class HierarchicalPin():
@@ -1320,17 +1406,22 @@ class HierarchicalPin():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['pin', escape_and_quote(self.name), self.connectionType]
 
-        expression =  f'{indents}(pin "{dequote(self.name)}" {self.connectionType} (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA})\n'
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += self.effects.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        expr.append(self.effects._to_sexpr_raw())
+        return expr
 
 
 @dataclass
@@ -1391,9 +1482,12 @@ class HierarchicalSheetProjectPath():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        return f'{indents}(path "{dequote(self.sheetInstancePath)}" (page "{dequote(self.page)}")){endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        return ['path', escape_and_quote(self.sheetInstancePath), ['page', escape_and_quote(self.page)]]
+
 
 @dataclass
 class HierarchicalSheetProjectInstance(ProjectInstance):
@@ -1452,13 +1546,17 @@ class HierarchicalSheetProjectInstance(ProjectInstance):
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        expression = f'{indents}(project "{dequote(self.name)}"\n'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['project', escape_and_quote(self.name)]
+
         for path in self.paths:
-            expression += path.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(path._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class HierarchicalSheet():
@@ -1583,35 +1681,48 @@ class HierarchicalSheet():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        exclude_from_sim = f' (exclude_from_sim {self.exclude_from_sim})' if self.exclude_from_sim is not None else ''
-        in_bom = f' (in_bom {self.in_bom})' if self.in_bom is not None else ''
-        on_board = f' (on_board {self.on_board})' if self.on_board is not None else ''
-        dnp = f' (dnp {self.dnp})' if self.dnp is not None else ''
-        fa = f' {format_bool("fields_autoplaced", self.fieldsAutoplaced)}'
+    def _to_sexpr_raw(self):
+        expr = ['sheet']
 
-        expression =  (f'{indents}(sheet '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}) '
-                       f'(size {format_float(self.width)} {format_float(self.height)}){exclude_from_sim}{in_bom}{on_board}{dnp}{fa}\n')
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += f'{indents}  (fill {self.fill.to_sexpr()})\n'
+        expr.append(['at', format_float(self.position.X), format_float(self.position.Y)])
+        expr.append(['size', format_float(self.width), format_float(self.height)])
+
+        if self.exclude_from_sim is not None:
+            expr.append(['exclude_from_sim', self.exclude_from_sim])
+        if self.in_bom is not None:
+            expr.append(['in_bom', self.in_bom])
+        if self.on_board is not None:
+            expr.append(['on_board', self.on_board])
+        if self.dnp is not None:
+            expr.append(['dnp', self.dnp])
+
+        expr.append(format_bool_raw('fields_autoplaced', self.fieldsAutoplaced))
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(['fill', self.fill._to_sexpr_raw()])
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += self.sheetName.to_sexpr(indent+2)
-        expression += self.fileName.to_sexpr(indent+2)
+            expr.append(['uuid', quote(self.uuid)])
+
+        expr.append(self.sheetName._to_sexpr_raw())
+        expr.append(self.fileName._to_sexpr_raw())
+
         for p in self.properties:
-            expression += p.to_sexpr(indent+2)
+            expr.append(p._to_sexpr_raw())
+
         for pin in self.pins:
-            expression += pin.to_sexpr(indent+2)
+            expr.append(pin._to_sexpr_raw())
+
         if len(self.instances) != 0:
-            expression += f'{indents}  (instances\n'
+            instances_expr = ['instances']
             for instance in self.instances:
-                expression += instance.to_sexpr(indent+4)
-            expression += f'{indents}  )\n'
-        expression += f'{indents}){endline}'
-        return expression
+                instances_expr.append(instance._to_sexpr_raw())
+            expr.append(instances_expr)
+
+        return expr
+
 
 @dataclass
 class HierarchicalSheetInstance():
@@ -1670,10 +1781,12 @@ class HierarchicalSheetInstance():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(path "{dequote(self.instancePath)}" (page "{dequote(self.page)}")){endline}'
+    def _to_sexpr_raw(self):
+        return ['path', escape_and_quote(self.instancePath), ['page', escape_and_quote(self.page)]]
+
 
 @dataclass
 class SymbolInstance():
@@ -1744,13 +1857,19 @@ class SymbolInstance():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(path "{dequote(self.path)}"\n'
-        expression += f'{indents}  (reference "{dequote(self.reference)}") (unit {self.unit}) (value "{dequote(self.value)}") (footprint "{dequote(self.footprint)}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        expr = ['path', escape_and_quote(self.path)]
+
+        expr.append(['reference', escape_and_quote(self.reference)])
+        expr.append(['unit', self.unit])
+        expr.append(['value', escape_and_quote(self.value)])
+        expr.append(['footprint', escape_and_quote(self.footprint)])
+
+        return expr
+
 
 @dataclass
 class Rectangle():
@@ -1820,16 +1939,22 @@ class Rectangle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(rectangle (start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})\n'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
+    def _to_sexpr_raw(self):
+        expr = ['rectangle',
+                ['start', format_float(self.start.X), format_float(self.start.Y)],
+                ['end', format_float(self.end.X), format_float(self.end.Y)]]
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class Arc():
@@ -1903,17 +2028,23 @@ class Arc():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  (f'{indents}(arc (start {format_float(self.start.X)} {format_float(self.start.Y)}) '
-                       f'(mid {format_float(self.mid.X)} {format_float(self.mid.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})\n')
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
+    def _to_sexpr_raw(self):
+        expr = ['arc',
+                ['start', format_float(self.start.X), format_float(self.start.Y)],
+                ['mid', format_float(self.mid.X), format_float(self.mid.Y)],
+                ['end', format_float(self.end.X), format_float(self.end.Y)]]
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
 
 @dataclass
 class Circle():
@@ -1983,17 +2114,23 @@ class Circle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(circle (center {format_float(self.center.X)} {format_float(self.center.Y)}) (radius {format_float(self.radius)})\n'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
+    def _to_sexpr_raw(self):
+        expr = ['circle',
+                ['center', format_float(self.center.X), format_float(self.center.Y)],
+                ['radius', format_float(self.radius)]]
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        expression += f'{indents}){endline}'
-        return expression
-    
+            expr.append(['uuid', quote(self.uuid)])
+
+        return expr
+
+
 @dataclass
 class NetclassFlag():
     """The ``netclass_flag`` token defines a netclass flag in a schematic.
@@ -2077,21 +2214,30 @@ class NetclassFlag():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        fa = f' {format_bool("fields_autoplaced", self.fieldsAutoplaced)}'
+    def _to_sexpr_raw(self):
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
 
-        expression =  (f'{indents}(netclass_flag "{dequote(self.text)}" (length {format_float(self.length)}) (shape {self.shape}) '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}){fa}\n')
-        expression += self.effects.to_sexpr(indent+2)
+        expr = ['netclass_flag', escape_and_quote(self.text),
+                ['length', format_float(self.length)],
+                ['shape', self.shape],
+                pos,
+                format_bool_raw('fields_autoplaced', self.fieldsAutoplaced)]
+
+        expr.append(self.effects._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid "{self.uuid}")\n'
-        for property in self.properties:
-            expression += property.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', quote(self.uuid)])
+
+        for prop in self.properties:
+            expr.append(prop._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class TableBorder:
@@ -2145,17 +2291,20 @@ class TableBorder:
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' ' * indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(border\n'
-        expression += format_bool('external', self.external)
-        expression += format_bool('header', self.header)
+    def _to_sexpr_raw(self):
+        expr = ['border']
+
+        expr.append(format_bool_raw('external', self.external))
+        expr.append(format_bool_raw('header', self.header))
+
         if self.stroke is not None:
-            expression += self.stroke.to_sexpr()
+            expr.append(self.stroke._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+
 
 @dataclass
 class TableSeparators:
@@ -2209,17 +2358,20 @@ class TableSeparators:
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' ' * indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(separators\n'
-        expression += format_bool('rows', self.rows)
-        expression += format_bool('cols', self.columns)
+    def _to_sexpr_raw(self):
+        expr = ['separators']
+
+        expr.append(format_bool_raw('rows', self.rows))
+        expr.append(format_bool_raw('cols', self.columns))
+
         if self.stroke is not None:
-            expression += self.stroke.to_sexpr()
+            expr.append(self.stroke._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr
+
 
 @dataclass
 class Table():
@@ -2295,29 +2447,27 @@ class Table():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(table\n'
-        expression += f'{indents}(column_count {self.column_count})\n'
+    def _to_sexpr_raw(self):
+        expr = ['table']
+
+        expr.append(['column_count', self.column_count])
 
         if self.border is not None:
-            expression += self.border.to_sexpr()
+            expr.append(self.border._to_sexpr_raw())
 
         if self.separators is not None:
-            expression += self.separators.to_sexpr()
+            expr.append(self.separators._to_sexpr_raw())
 
-        cols_widths_str = " ".join([format_float(w) for w in self.column_widths])
-        expression += f'{indents}(column_widths {cols_widths_str})\n'
+        expr.append(['column_widths'] + [format_float(w) for w in self.column_widths])
+        expr.append(['row_heights'] + [format_float(h) for h in self.row_heights])
 
-        rows_heights_str = " ".join([format_float(h) for h in self.row_heights])
-        expression += f'{indents}(row_heights {rows_heights_str})\n'
-
-        if len(self.cells) > 0:
-            expression += f'{indents}(cells\n'
+        if self.cells:
+            cells_expr = ['cells']
             for cell in self.cells:
-                expression += cell.to_sexpr(table_cell=True)
-            expression += f'{indents}){endline}'
+                cells_expr.append(cell._to_sexpr_raw(table_cell=True))
+            expr.append(cells_expr)
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr

--- a/src/kiutils/items/syitems.py
+++ b/src/kiutils/items/syitems.py
@@ -21,9 +21,10 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from kiutils.items.common import Position, Stroke, Effects, Fill
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class SyArc():
@@ -99,22 +100,32 @@ class SyArc():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        startA = f' {format_float(self.start.angle)}' if self.start.angle is not None else ''
-        midA = f' {format_float(self.mid.angle)}' if self.mid.angle is not None else ''
-        endA = f' {format_float(self.end.angle)}' if self.end.angle is not None else ''
-        private = f' {format_bool("private", self.private, compact=True)}'
+    def _to_sexpr_raw(self):
+        expr = ['arc', format_bool_raw('private', self.private, compact=True)]
 
-        expression =  (f'{indents}(arc{private} '
-                       f'(start {format_float(self.start.X)} {format_float(self.start.Y)}{startA}) '
-                       f'(mid {format_float(self.mid.X)} {format_float(self.mid.Y)}{midA}) '
-                       f'(end {format_float(self.end.X)} {format_float(self.end.Y)}{endA})\n')
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+        start = ['start', format_float(self.start.X), format_float(self.start.Y)]
+        if self.start.angle is not None:
+            start.append(format_float(self.start.angle))
+        expr.append(start)
+
+        mid = ['mid', format_float(self.mid.X), format_float(self.mid.Y)]
+        if self.mid.angle is not None:
+            mid.append(format_float(self.mid.angle))
+        expr.append(mid)
+
+        end = ['end', format_float(self.end.X), format_float(self.end.Y)]
+        if self.end.angle is not None:
+            end.append(format_float(self.end.angle))
+        expr.append(end)
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyCircle():
@@ -186,15 +197,19 @@ class SyCircle():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        private = f' {format_bool("private", self.private, compact=True)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(circle{private} (center {format_float(self.center.X)} {format_float(self.center.Y)}) (radius {format_float(self.radius)})\n'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        expr = ['circle', format_bool_raw('private', self.private, compact=True)]
+
+        expr.append(['center', format_float(self.center.X), format_float(self.center.Y)])
+        expr.append(['radius', format_float(self.radius)])
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyCurve():
@@ -256,19 +271,22 @@ class SyCurve():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression  =  f'{indents}(curve\n'
-        expression +=  f'{indents}  (pts\n'
+    def _to_sexpr_raw(self):
+        expr = ['curve']
+
+        pts = ['pts']
         for point in self.points:
-            expression +=  f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression +=  f'{indents}  )\n'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
+            pts.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts)
 
-        return expression
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyPolyLine():
@@ -330,18 +348,22 @@ class SyPolyLine():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  f'{indents}(polyline\n'
-        expression +=  f'{indents}  (pts\n'
+    def _to_sexpr_raw(self):
+        expr = ['polyline']
+
+        pts = ['pts']
         for point in self.points:
-            expression +=  f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  )\n'
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+            pts.append(['xy', format_float(point.X), format_float(point.Y)])
+        expr.append(pts)
+
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyRect():
@@ -414,16 +436,19 @@ class SyRect():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        private = f' {format_bool("private", self.private, compact=True)}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression =  (f'{indents}(rectangle{private} '
-                       f'(start {format_float(self.start.X)} {format_float(self.start.Y)}) (end {format_float(self.end.X)} {format_float(self.end.Y)})\n')
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
-        return expression
+    def _to_sexpr_raw(self):
+        expr = ['rectangle', format_bool_raw('private', self.private, compact=True)]
+
+        expr.append(['start', format_float(self.start.X), format_float(self.start.Y)])
+        expr.append(['end', format_float(self.end.X), format_float(self.end.Y)])
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyText():
@@ -484,15 +509,21 @@ class SyText():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['text', escape_and_quote(self.text)]
 
-        expression =  f'{indents}(text "{dequote(self.text)}" (at {format_float(self.position.X)} {format_float(self.position.Y)}{posA})\n'
-        expression += f'{indents}  {self.effects.to_sexpr()}'
-        expression += f'{indents}){endline}'
-        return expression
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(self.effects._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class SyTextBox():
@@ -586,19 +617,23 @@ class SyTextBox():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        private = f' {format_bool("private", self.private, compact=True)}'
+    def _to_sexpr_raw(self):
+        expr = ['text_box', format_bool_raw('private', self.private, compact=True), escape_and_quote(self.text)]
 
-        expression =  f'{indents}(text_box{private} "{dequote(self.text)}"\n'
-        expression += (f'{indents} '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}) (size {format_float(self.size.X)} {format_float(self.size.Y)})\n')
-        expression += self.stroke.to_sexpr(indent+2)
-        expression += self.fill.to_sexpr(indent+2)
-        expression += self.effects.to_sexpr(indent+2)
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(['size', format_float(self.size.X), format_float(self.size.Y)])
+        expr.append(self.stroke._to_sexpr_raw())
+        expr.append(self.fill._to_sexpr_raw())
+        expr.append(self.effects._to_sexpr_raw())
+
         if self.uuid is not None:
-            expression += f'{indents}  (uuid {self.uuid})\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['uuid', self.uuid])
+
+        return expr

--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -249,7 +249,10 @@ class FillSettings():
         return sexp_to_string(raw_expr)
 
     def _to_sexpr_raw(self):
-        expr = ['fill ' + format_bool('yes', self.yes, compact=True)]
+        expr = ['fill']
+
+        if self.yes:
+            expr.append('yes')
 
         if self.mode is not None:
             expr.append(['mode', self.mode])

--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -20,9 +20,10 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 
 from kiutils.items.common import Position
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.string_utils import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw, format_bool
+from kiutils.utils.sexpr import sexp_to_string
 
 @dataclass
 class KeepoutSettings():
@@ -98,11 +99,19 @@ class KeepoutSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        # KiCad seems to add a whitespace to the pad token here
-        return f'{indents}(keepout (tracks {self.tracks}) (vias {self.vias}) (pads {self.pads} ) (copperpour {self.copperpour}) (footprints {self.footprints})){endline}'
+    def _to_sexpr_raw(self):
+        return [
+            'keepout',
+            ['tracks', self.tracks],
+            ['vias', self.vias],
+            ['pads', self.pads],
+            ['copperpour', self.copperpour],
+            ['footprints', self.footprints]
+        ]
+
 
 @dataclass
 class FillSettings():
@@ -236,24 +245,53 @@ class FillSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        yes = f' {format_bool("yes", self.yes, compact=True)}'
-        mode = f' (mode {self.mode})' if self.mode is not None else ''
-        smoothing = f' (smoothing {self.smoothingStyle})' if self.smoothingStyle is not None else ''
-        radius = f' (radius {self.smoothingRadius})' if self.smoothingRadius is not None else ''
-        irm = f' (island_removal_mode {self.islandRemovalMode})' if self.islandRemovalMode is not None else ''
-        iam = f' (island_area_min {self.islandAreaMin})' if self.islandAreaMin is not None else ''
-        ht = f'\n{indents}  (hatch_thickness {self.hatchThickness})' if self.hatchThickness is not None else ''
-        hg = f' (hatch_gap {self.hatchGap})' if self.hatchGap is not None else ''
-        ho = f' (hatch_orientation {self.hatchOrientation})' if self.hatchOrientation is not None else ''
-        hsl = f'\n{indents}  (hatch_smoothing_level {self.hatchSmoothingLevel})' if self.hatchSmoothingLevel is not None else ''
-        hsv = f' (hatch_smoothing_value {self.hatchSmoothingValue})' if self.hatchSmoothingValue is not None else ''
-        hba = f'\n{indents}  (hatch_border_algorithm {self.hatchBorderAlgorithm})' if self.hatchBorderAlgorithm is not None else ''
-        hmha = f' (hatch_min_hole_area {self.hatchMinHoleArea})' if self.hatchMinHoleArea is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['fill ' + format_bool('yes', self.yes, compact=True)]
 
-        return f'{indents}(fill{yes}{mode} (thermal_gap {self.thermalGap}) (thermal_bridge_width {self.thermalBridgeWidth}){smoothing}{radius}{irm}{iam}{ht}{hg}{ho}{hsl}{hsv}{hba}{hmha}){endline}'
+        if self.mode is not None:
+            expr.append(['mode', self.mode])
+
+        expr.append(['thermal_gap', self.thermalGap])
+        expr.append(['thermal_bridge_width', self.thermalBridgeWidth])
+
+        if self.smoothingStyle is not None:
+            expr.append(['smoothing', self.smoothingStyle])
+
+        if self.smoothingRadius is not None:
+            expr.append(['radius', self.smoothingRadius])
+
+        if self.islandRemovalMode is not None:
+            expr.append(['island_removal_mode', self.islandRemovalMode])
+
+        if self.islandAreaMin is not None:
+            expr.append(['island_area_min', self.islandAreaMin])
+
+        if self.hatchThickness is not None:
+            expr.append(['hatch_thickness', self.hatchThickness])
+
+        if self.hatchGap is not None:
+            expr.append(['hatch_gap', self.hatchGap])
+
+        if self.hatchOrientation is not None:
+            expr.append(['hatch_orientation', self.hatchOrientation])
+
+        if self.hatchSmoothingLevel is not None:
+            expr.append(['hatch_smoothing_level', self.hatchSmoothingLevel])
+
+        if self.hatchSmoothingValue is not None:
+            expr.append(['hatch_smoothing_value', self.hatchSmoothingValue])
+
+        if self.hatchBorderAlgorithm is not None:
+            expr.append(['hatch_border_algorithm', self.hatchBorderAlgorithm])
+
+        if self.hatchMinHoleArea is not None:
+            expr.append(['hatch_min_hole_area', self.hatchMinHoleArea])
+
+        return expr
+
 
 @dataclass
 class ZonePolygon():
@@ -302,21 +340,19 @@ class ZonePolygon():
             - newline (bool): Adds a newline to the end of the output. Defaults to True.
 
         Returns:
-            - str: S-Expression of this object. If the polygon has no coordinates, an empty 
+            - str: S-Expression of this object. If the polygon has no coordinates, an empty
                    expression is returned.
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
         if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+            return ''
 
-        expression =  f'{indents}(polygon\n'
-        expression += f'{indents}  (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  )\n'
-        expression += f'{indents})\n'
-        return expression
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        pts = [['xy', format_float(point.X), format_float(point.Y)] for point in self.coordinates]
+        return ['polygon', ['pts'] + pts]
+
 
 @dataclass
 class FilledPolygon():
@@ -378,23 +414,26 @@ class FilledPolygon():
             - newline (bool): Adds a newline to the end of the output. Defaults to True.
 
         Returns:
-            - str: S-Expression of this object. If the filled polygon has no coordinates, an empty 
+            - str: S-Expression of this object. If the filled polygon has no coordinates, an empty
                    expression is returned.
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
         if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+            return ''
 
-        expression =  f'{indents}(filled_polygon\n'
-        expression += f'{indents}  (layer "{dequote(self.layer)}")\n'
-        expression += f'{indents}  (island)\n' if self.island else ''
-        expression += f'{indents}  (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  )\n'
-        expression += f'{indents})\n'
-        return expression
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['filled_polygon', ['layer', escape_and_quote(self.layer)]]
+
+        if self.island:
+            expr.append(['island'])
+
+        pts = [['xy', format_float(point.X), format_float(point.Y)] for point in self.coordinates]
+        expr.append(['pts'] + pts)
+
+        return expr
+
 
 # TODO: This is KiCad 4 stuff, has to be tested yet ..
 @dataclass
@@ -453,22 +492,19 @@ class FillSegments():
             - newline (bool): Adds a newline to the end of the output. Defaults to True.
 
         Returns:
-            - str: S-Expression of this object. If the fill segments has no coordinates, an empty 
+            - str: S-Expression of this object. If the fill segments has no coordinates, an empty
               expression is returned.
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
         if len(self.coordinates) == 0:
-            return f'{indents}{endline}'
+            return ''
 
-        expression =  f'{indents}(fill_segments\n'
-        expression += f'{indents}  (layer "{dequote(self.layer)}")\n'
-        expression += f'{indents}  (pts\n'
-        for point in self.coordinates:
-            expression += f'{indents}    (xy {format_float(point.X)} {format_float(point.Y)})\n'
-        expression += f'{indents}  )\n'
-        expression += f'{indents})\n'
-        return expression
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        pts = [['xy', format_float(point.X), format_float(point.Y)] for point in self.coordinates]
+        return ['fill_segments', ['layer', escape_and_quote(self.layer)], ['pts'] + pts]
+
 
 @dataclass
 class Hatch():
@@ -624,48 +660,68 @@ class Zone():
         Returns:
             - str: S-Expression of this object.
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        locked = f' {format_bool("locked", self.locked)}'
-        tstamp = f' (uuid "{self.tstamp}")' if self.tstamp is not None else ''
-        name = f' (name "{dequote(self.name)}")' if self.name is not None else ''
-        contype = f' {self.connectPads}' if self.connectPads is not None else ''
-        fat = f' (filled_areas_thickness {self.filledAreasThickness})' if self.filledAreasThickness is not None else ''
-        layers, layer_token = '', ''
-        for layer in self.layers:
-            layers += f' "{dequote(layer)}"'
-            
+    def _to_sexpr_raw(self):
         if len(self.layers) == 0:
             raise Exception("Zone: No layers set for this zone")
-        elif len(self.layers) == 1 and self.layers[0] != "F&B.Cu" and self.layers[0] != "*.Cu":
-            layer_token = f' (layer{layers})'
-        else:
-            layer_token = f' (layers{layers})'
 
-        expression =  f'{indents}(zone (net {self.net}) (net_name "{dequote(self.netName)}"){locked}{layer_token}{tstamp}{name} (hatch {self.hatch.style} {self.hatch.pitch})\n'
+        layers_list = [escape_and_quote(layer) for layer in self.layers]
+        if len(self.layers) == 1 and self.layers[0] != "F&B.Cu" and self.layers[0] != "*.Cu":
+            layer_token = 'layer'
+        else:
+            layer_token = 'layers'
+
+        expr = ['zone',
+                ['net', self.net],
+                ['net_name', escape_and_quote(self.netName)],
+                format_bool_raw('locked', self.locked),
+                [layer_token] + layers_list
+                ]
+
+        if self.tstamp is not None:
+            expr.append(['uuid', quote(self.tstamp)])
+
+        if self.name is not None:
+            expr.append(['name', escape_and_quote(self.name)])
+
+        expr.append(['hatch', self.hatch.style, self.hatch.pitch])
+
         if self.priority is not None:
-            expression += f'{indents}  (priority {self.priority})\n'
-        expression += f'{indents}  (connect_pads{contype} (clearance {self.clearance}))\n'
-        expression += f'{indents}  (min_thickness {self.minThickness}){fat}\n'
+            expr.append(['priority', self.priority])
+
+        connect_pads_expr = ['connect_pads']
+        if self.connectPads is not None:
+            connect_pads_expr.append(self.connectPads)
+        connect_pads_expr.append(['clearance', self.clearance])
+        expr.append(connect_pads_expr)
+
+        expr.append(['min_thickness', self.minThickness])
+
+        if self.filledAreasThickness is not None:
+            expr.append(['filled_areas_thickness', self.filledAreasThickness])
+
         if self.keepoutSettings is not None:
-            expression += f'{indents}  {self.keepoutSettings.to_sexpr()}\n'
+            expr.append(self.keepoutSettings._to_sexpr_raw())
+
         if self.placement is not None:
-            expression += f'{indents} {self.placement.to_sexpr()}\n'
+            expr.append(self.placement._to_sexpr_raw())
+
         if self.fillSettings is not None:
-            expression += self.fillSettings.to_sexpr(indent+2, True)
+            expr.append(self.fillSettings._to_sexpr_raw())
 
         for polygon in self.polygons:
-            expression += polygon.to_sexpr(indent+2)
+            expr.append(polygon._to_sexpr_raw())
 
         for polygon in self.filledPolygons:
-            expression += polygon.to_sexpr(indent+2)
+            expr.append(polygon._to_sexpr_raw())
 
-        # TODO: This is KiKad 4 stuff...
         if self.fillSegments is not None:
-            expression += self.fillSegments.to_sexpr()
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(self.fillSegments._to_sexpr_raw())
+
+        return expr
+
 
 @dataclass
 class PlacementSettings():
@@ -716,8 +772,12 @@ class PlacementSettings():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        # KiCad seems to add a whitespace to the pad token here
-        return f'{indents}(placement (enabled {self.enabled}) (sheetname "{self.sheet_name}")){endline}'
+    def _to_sexpr_raw(self):
+        return [
+            'placement',
+            ['enabled', self.enabled],
+            ['sheetname', quote(self.sheet_name)]
+        ]

--- a/src/kiutils/items/zones.py
+++ b/src/kiutils/items/zones.py
@@ -109,7 +109,7 @@ class KeepoutSettings():
             ['vias', self.vias],
             ['pads', self.pads],
             ['copperpour', self.copperpour],
-            ['footprints', self.footprints]
+            ['footprints', self.footprints],
         ]
 
 
@@ -430,7 +430,7 @@ class FilledPolygon():
         expr = ['filled_polygon', ['layer', escape_and_quote(self.layer)]]
 
         if self.island:
-            expr.append(['island'])
+            expr.append(format_bool_raw('island', self.island, compact=True))
 
         pts = [['xy', format_float(point.X), format_float(point.Y)] for point in self.coordinates]
         expr.append(['pts'] + pts)
@@ -506,7 +506,11 @@ class FillSegments():
 
     def _to_sexpr_raw(self):
         pts = [['xy', format_float(point.X), format_float(point.Y)] for point in self.coordinates]
-        return ['fill_segments', ['layer', escape_and_quote(self.layer)], ['pts'] + pts]
+        return [
+            'fill_segments',
+            ['layer', escape_and_quote(self.layer)],
+            ['pts'] + pts,
+        ]
 
 
 @dataclass
@@ -676,12 +680,13 @@ class Zone():
         else:
             layer_token = 'layers'
 
-        expr = ['zone',
-                ['net', self.net],
-                ['net_name', escape_and_quote(self.netName)],
-                format_bool_raw('locked', self.locked),
-                [layer_token] + layers_list
-                ]
+        expr = [
+            'zone',
+            ['net', self.net],
+            ['net_name', escape_and_quote(self.netName)],
+            format_bool_raw('locked', self.locked),
+            [layer_token] + layers_list,
+        ]
 
         if self.tstamp is not None:
             expr.append(['uuid', quote(self.tstamp)])
@@ -782,5 +787,5 @@ class PlacementSettings():
         return [
             'placement',
             ['enabled', self.enabled],
-            ['sheetname', quote(self.sheet_name)]
+            ['sheetname', quote(self.sheet_name)],
         ]

--- a/src/kiutils/libraries.py
+++ b/src/kiutils/libraries.py
@@ -16,9 +16,8 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 from os import path
 
-from kiutils.utils.string_utils import dequote
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
+from kiutils.utils.string_utils import *
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
 
 @dataclass
 class Library():
@@ -90,25 +89,26 @@ class Library():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}(lib '
-        expression += f'(name "{dequote(self.name)}")'
-        expression += f'(type "{dequote(self.type)}")'
-        expression += f'(uri "{dequote(self.uri)}")'
-        expression += f'(options "{dequote(self.options)}")'
-        expression += f'(descr "{dequote(self.description)}")'
+    def _to_sexpr_raw(self):
+        expr = ['lib']
+
+        expr.append(['name', escape_and_quote(self.name)])
+        expr.append(['type', escape_and_quote(self.type)])
+        expr.append(['uri', escape_and_quote(self.uri)])
+        expr.append(['options', escape_and_quote(self.options)])
+        expr.append(['descr', escape_and_quote(self.description)])
 
         if not self.active:
-            expression += '(disabled)'
+            expr.append(['disabled'])
 
         if not self.visible:
-            expression += '(hidden)'
+            expr.append(['hidden'])
 
-        expression += f'){endline}'
+        return expr
 
-        return expression
 
 @dataclass
 class LibTable():
@@ -174,7 +174,7 @@ class LibTable():
             raise Exception("Given path is not a file!")
 
         with open(filepath, 'r', encoding=encoding) as infile:
-            item = cls.from_sexpr(sexpr.parse_sexp(infile.read()))
+            item = cls.from_sexpr(parse_sexp(infile.read()))
             item.filePath = filepath
             return item
 
@@ -221,11 +221,13 @@ class LibTable():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        expression = f'{indents}({self.type}\n'
+    def _to_sexpr_raw(self):
+        expr = [self.type]
+
         for lib in self.libs:
-            expression += lib.to_sexpr()
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(lib._to_sexpr_raw())
+
+        return expr

--- a/src/kiutils/schematic.py
+++ b/src/kiutils/schematic.py
@@ -21,10 +21,10 @@ from os import path
 from kiutils.items.common import Image, PageSettings, TitleBlock
 from kiutils.items.schitems import *
 from kiutils.symbol import Symbol
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
 from kiutils.misc.config import *
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool, format_bool_raw
+from kiutils.utils.string_utils import *
 
 @dataclass
 class Schematic():
@@ -212,7 +212,7 @@ class Schematic():
             raise Exception(f"Given path ('{filepath}') is not a file!")
 
         with open(filepath, 'r', encoding=encoding) as infile:
-            item = cls.from_sexpr(sexpr.parse_sexp(infile.read()))
+            item = cls.from_sexpr(parse_sexp(infile.read()))
             item.filePath = filepath
             return item
 
@@ -262,129 +262,79 @@ class Schematic():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        generator_version = f' (generator_version "{self.generator_version}")' if self.generator_version is not None else ''
-        expression =  f'{indents}(kicad_sch (version {self.version}) (generator "{self.generator}"){generator_version}\n'
+    def _to_sexpr_raw(self):
+        expr = [
+            'kicad_sch',
+            ['version', self.version],
+            ['generator', quote(self.generator)]
+        ]
+
+        if self.generator_version is not None:
+            expr.append(['generator_version', quote(self.generator_version)])
+
         if self.uuid is not None:
-            expression += f' (uuid "{self.uuid}"){endline}'
-        expression += f'{self.paper.to_sexpr(indent+2)}'
+            expr.append(['uuid', quote(self.uuid)])
+
+        expr.append(self.paper._to_sexpr_raw())
+
         if self.titleBlock is not None:
-            expression += f'\n{self.titleBlock.to_sexpr(indent+2)}'
+            expr.append(self.titleBlock._to_sexpr_raw())
 
         if self.libSymbols:
-            expression += f'\n{indents}  (lib_symbols'
-            for item in self.libSymbols:
-                expression += '\n'
-                expression += item.to_sexpr(indent+4)
-            expression += f'{indents}  )\n'
+            expr.append(['lib_symbols'] + [item._to_sexpr_raw() for item in self.libSymbols])
         else:
-            expression += f'{indents}  (lib_symbols)\n'
-
-        if self.texts:
-            expression += '\n'
-            for item in self.texts:
-                expression += item.to_sexpr(indent + 2)
-
-        if self.textBoxes:
-            expression += '\n'
-            for item in self.textBoxes:
-                expression += item.to_sexpr(indent + 2)
-
-        if self.junctions:
-            expression += '\n'
-            for item in self.junctions:
-                expression += item.to_sexpr(indent+2)
-
-        if self.noConnects:
-            expression += '\n'
-            for item in self.noConnects:
-                expression += item.to_sexpr(indent+2)
-
-        if self.busEntries:
-            expression += '\n'
-            for item in self.busEntries:
-                expression += item.to_sexpr(indent+2)
+            expr.append(['lib_symbols'])
 
         if self.busAliases:
-            expression += '\n'
-            for item in self.busAliases:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.busAliases)
+        if self.texts:
+            expr.extend(item._to_sexpr_raw() for item in self.texts)
+        if self.textBoxes:
+            expr.extend(item._to_sexpr_raw() for item in self.textBoxes)
+        if self.junctions:
+            expr.extend(item._to_sexpr_raw() for item in self.junctions)
+        if self.noConnects:
+            expr.extend(item._to_sexpr_raw() for item in self.noConnects)
+        if self.busEntries:
+            expr.extend(item._to_sexpr_raw() for item in self.busEntries)
         if self.graphicalItems:
-            expression += '\n'
-            for item in self.graphicalItems:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.graphicalItems)
         if self.tables:
-            expression += '\n'
-            for item in self.tables:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.tables)
         if self.shapes:
-            expression += '\n'
-            for item in self.shapes:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.shapes)
         if self.images:
-            expression += '\n'
-            for item in self.images:
-                expression += item.to_sexpr(indent+2)
-
-
+            expr.extend(item._to_sexpr_raw() for item in self.images)
         if self.labels:
-            expression += '\n'
-            for item in self.labels:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.labels)
         if self.globalLabels:
-            expression += '\n'
-            for item in self.globalLabels:
-                expression += item.to_sexpr(indent+2)
-
+            expr.extend(item._to_sexpr_raw() for item in self.globalLabels)
         if self.hierarchicalLabels:
-            expression += '\n'
-            for item in self.hierarchicalLabels:
-                expression += item.to_sexpr(indent+2)
+            expr.extend(item._to_sexpr_raw() for item in self.hierarchicalLabels)
 
         if len(self.rule_areas) > 0:
             for ra in self.rule_areas:
-                expression += f'{indents}(rule_area{endline}'
-                expression += ra.to_sexpr(indent+2)
-                expression += f'{indents}){endline}'
+                expr.append(['rule_area', ra._to_sexpr_raw()])
 
         if self.netclassFlags:
-            expression += '\n'
-            for item in self.netclassFlags:
-                expression += item.to_sexpr(indent+2)
+            expr.extend(item._to_sexpr_raw() for item in self.netclassFlags)
 
         if self.schematicSymbols:
-            for item in self.schematicSymbols:
-                expression += '\n'
-                expression += item.to_sexpr(indent+2)
+            expr.extend(item._to_sexpr_raw() for item in self.schematicSymbols)
 
         if self.sheets:
-            for item in self.sheets:
-                expression += '\n'
-                expression += item.to_sexpr(indent+2)
+            expr.extend(item._to_sexpr_raw() for item in self.sheets)
 
         if self.sheetInstances:
-            expression += '\n'
-            expression += '  (sheet_instances\n'
-            for item in self.sheetInstances:
-                expression += item.to_sexpr(indent+4)
-            expression += '  )\n'
+            expr.append(['sheet_instances'] + [item._to_sexpr_raw() for item in self.sheetInstances])
 
         if self.symbolInstances:
-            expression += '\n'
-            expression += '  (symbol_instances\n'
-            for item in self.symbolInstances:
-                expression += item.to_sexpr(indent+4)
-            expression += '  )\n'
+            expr.append(['symbol_instances'] + [item._to_sexpr_raw() for item in self.symbolInstances])
 
         if self.embedded_fonts is not None:
-            expression += f'{indents} {format_bool("embedded_fonts", self.embedded_fonts, compact=False, yesno=True)}\n'
+            expr.append(format_bool_raw('embedded_fonts', self.embedded_fonts, compact=False, yesno=True))
 
-        expression += f'{indents}){endline}'
-        return expression
+        return expr

--- a/src/kiutils/symbol.py
+++ b/src/kiutils/symbol.py
@@ -19,12 +19,11 @@ import re
 
 from kiutils.items.common import Property, Font, EmbeddedFile
 from kiutils.items.syitems import *
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
-from kiutils.utils.string_utils import dequote
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
+from kiutils.utils.string_utils import *
 from kiutils.misc.config import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool, format_bool_raw
 
 
 @dataclass
@@ -77,10 +76,12 @@ class SymbolAlternativePin():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        return f'{indents}(alternate "{dequote(self.pinName)}" {self.electricalType} {self.graphicalStyle}){endline}'
+    def _to_sexpr_raw(self):
+        return ['alternate', escape_and_quote(self.pinName), self.electricalType, self.graphicalStyle]
+
 
 @dataclass
 class SymbolPin():
@@ -176,41 +177,38 @@ class SymbolPin():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        newLineAdded = False
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        hide = f' {format_bool("hide", self.hide)}'
-        posA = f' {format_float(self.position.angle)}' if self.position.angle is not None else ''
-        nameEffects = f' {self.nameEffects.to_sexpr(newline=False)}' if self.nameEffects is not None else ''
-        numberEffects = f' {self.numberEffects.to_sexpr(newline=False)}' if self.numberEffects is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['pin', self.electricalType, self.graphicalStyle]
 
-        expression =  (f'{indents}(pin {self.electricalType} {self.graphicalStyle} '
-                       f'(at {format_float(self.position.X)} {format_float(self.position.Y)}{posA}) (length {format_float(self.length)}){hide}')
-        
-        # Since KiCad v7 nightly: Missing name and number effects print both other tokens into 
-        # the same line.
-        # Constrained in: schematic/since_v7/test_symbolPinOptionalTokens
+        pos = ['at', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.angle is not None:
+            pos.append(format_float(self.position.angle))
+        expr.append(pos)
+
+        expr.append(['length', format_float(self.length)])
+
+        if self.hide is not None:
+            expr.append(format_bool_raw('hide', self.hide))
+
+        # Name and number, with conditional line break handling
         if self.nameEffects is None and self.numberEffects is None:
-            expression += f' (name "{dequote(self.name)}") (number "{dequote(self.number)}")'
+            expr.append(['name', escape_and_quote(self.name)])
+            expr.append(['number', escape_and_quote(self.number)])
         else:
-            expression += f'\n{indents}  (name "{dequote(self.name)}"{nameEffects})\n'
-            expression += f'{indents}  (number "{dequote(self.number)}"{numberEffects})\n'
-            newLineAdded = True
+            expr.append(['name', escape_and_quote(self.name), self.nameEffects._to_sexpr_raw()])
+            expr.append(['number', escape_and_quote(self.number), self.numberEffects._to_sexpr_raw()])
 
-        # Alternative pins always generate a line break
         if self.alternatePins:
-            if not newLineAdded:
-                expression += '\n' 
-            newLineAdded = True
-            for alternativePin in self.alternatePins:
-                expression += alternativePin.to_sexpr(indent+2)
+            alternate_pins = ['alternate_pins']
+            for pin in self.alternatePins:
+                alternate_pins.append(pin._to_sexpr_raw())
+            expr.append(alternate_pins)
 
-        if newLineAdded:
-            expression += f'{indents}){endline}'
-        else:
-            expression += f'){endline}'
-        return expression
+        return expr
+
 
 @dataclass
 class Symbol():
@@ -360,10 +358,8 @@ class Symbol():
     units: List[Symbol] = field(default_factory=list)
     """The ``units`` can be one or more child symbol tokens embedded in a parent symbol"""
 
-    # Available since KiCad v9
-    # TODO Update docs
-
     exclude_from_sim: Optional[bool] = None
+    """The ``exclude_from_sim`` token indicates that component should not be taken into account during simulation"""
 
     embedded_fonts: Optional[bool] = None
     """The ``embedded_fonts`` token defines if the embedded fonts are used in the symbol."""
@@ -473,39 +469,55 @@ class Symbol():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        obtext, ibtext = '', ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        inbom = f' {format_bool("in_bom", self.inBom, compact=False, yesno=True)}' if self.inBom is not None else ''
-        onboard = f' {format_bool("on_board", self.onBoard, compact=False, yesno=True)}' if self.onBoard is not None else ''
-        power = f' ({format_bool("power", self.isPower, compact=True)})' if self.isPower else ''
-        exclude_from_sim = f' {format_bool("exclude_from_sim", self.exclude_from_sim, compact=False, yesno=True)}' if self.exclude_from_sim is not None else ''
-        pnhide = f' {format_bool("hide", self.pinNamesHide)}'
-        pnoffset = f' (offset {self.pinNamesOffset})' if self.pinNamesOffset is not None else ''
-        pinnames = f' (pin_names{pnoffset}{pnhide})' if self.pinNames else ''
-        pinnumbers = f' (pin_numbers (hide yes))' if self.hidePinNumbers else ''
-        extends = f' (extends "{dequote(self.extends)}")' if self.extends is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['symbol', escape_and_quote(self.libId)]
 
-        expression =  f'{indents}(symbol "{dequote(self.libId)}"{extends}{power}{pinnumbers}{pinnames}{exclude_from_sim}{inbom}{onboard}\n'
+        if self.extends is not None:
+            expr.append(['extends', escape_and_quote(self.extends)])
+
+        if self.isPower:
+            expr.append(['power'])
+
+        if self.hidePinNumbers:
+            expr.append(['pin_numbers', ['hide', 'yes']])
+
+        if self.pinNames:
+            pin_names = ['pin_names']
+            if self.pinNamesOffset is not None:
+                pin_names.append(['offset', self.pinNamesOffset])
+            if self.pinNamesHide:
+                pin_names.append(format_bool_raw('hide', self.pinNamesHide))
+            expr.append(pin_names)
+
+        if self.exclude_from_sim is not None:
+            expr.append(format_bool_raw('exclude_from_sim', self.exclude_from_sim, compact=False, yesno=True))
+        if self.inBom is not None:
+            expr.append(format_bool_raw('in_bom', self.inBom, compact=False, yesno=True))
+        if self.onBoard is not None:
+            expr.append(format_bool_raw('on_board', self.onBoard, compact=False, yesno=True))
+
         for item in self.properties:
-            expression += item.to_sexpr(indent+2)
+            expr.append(item._to_sexpr_raw())
         for item in self.graphicItems:
-            expression += item.to_sexpr(indent+2)
+            expr.append(item._to_sexpr_raw())
         for item in self.pins:
-            expression += item.to_sexpr(indent+2)
+            expr.append(item._to_sexpr_raw())
         for item in self.units:
-            expression += item.to_sexpr(indent+2)
-        if self.embedded_fonts is not None:
-            expression += f' {format_bool("embedded_fonts", self.embedded_fonts, compact=False, yesno=True)}{endline}'
-        if len(self.embedded_files) > 0:
-            expression += '(embedded_files'
-            for f in self.embedded_files:
-                expression += f' {f.to_sexpr(indent+2)}'
-            expression += ')'
+            expr.append(item._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
+        if self.embedded_fonts is not None:
+            expr.append(format_bool_raw('embedded_fonts', self.embedded_fonts, compact=False, yesno=True))
+
+        if len(self.embedded_files) > 0:
+            embedded_files = ['embedded_files']
+            for f in self.embedded_files:
+                embedded_files.append(f._to_sexpr_raw())
+            expr.append(embedded_files)
+
+        return expr
 
 @dataclass
 class SymbolLib():
@@ -534,6 +546,7 @@ class SymbolLib():
     """The ``generator_version`` token attribute defines the version of the program used to write the file"""
 
     embedded_fonts: Optional[str] = None
+    """The ``embedded_fonts`` token defines if the embedded fonts are used in the symbol library."""
 
     @classmethod
     def from_file(cls, filepath: str, encoding: Optional[str] = None) -> SymbolLib:
@@ -625,18 +638,26 @@ class SymbolLib():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' ' * indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        version = f' (version {self.version})' if self.version is not None else ''
-        generator = f' (generator "{self.generator}")' if self.generator is not None else ''
-        generator_version = f' (generator_version "{self.generator_version}")' if self.generator_version is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['kicad_symbol_lib']
 
-        expression =  f'{indents}(kicad_symbol_lib{version}{generator}{generator_version}\n'
+        if self.version is not None:
+            expr.append(['version', self.version])
+
+        if self.generator is not None:
+            expr.append(['generator', escape_and_quote(self.generator)])
+
+        if self.generator_version is not None:
+            expr.append(['generator_version', escape_and_quote(self.generator_version)])
+
+        # Add symbols to the raw expression
         for item in self.symbols:
-            expression += f'{indents}{item.to_sexpr(indent+2)}'
-        if self.embedded_fonts is not None:
-            expression += f' (embedded_fonts {self.embedded_fonts}){endline}'
+            expr.append(item._to_sexpr_raw())
 
-        expression += f'{indents}){endline}'
-        return expression
+        if self.embedded_fonts is not None:
+            expr.append(['embedded_fonts', self.embedded_fonts])
+
+        return expr

--- a/src/kiutils/utils/parsing_utils.py
+++ b/src/kiutils/utils/parsing_utils.py
@@ -18,8 +18,31 @@ def parse_bool(item: Union[list, str], key: str) -> bool:
 def format_bool(key: str, value: bool, compact: bool = False, yesno: bool = False) -> str:
     if not isinstance(value, bool):
         raise TypeError(f"Expected a boolean value, got {type(value).__name__}")
+
     if not yesno and not value:
         return ""
-    else:
-        return key if compact else (f"({key} yes)" if not yesno else f"({key} {'yes' if value else 'no'})")
+
+    if compact and value:
+        return key
+
+    if yesno:
+        return f"({key} {'yes' if value else 'no'})"
+
+    return f"({key} yes)"
+
+def format_bool_raw(key: str, value: bool, compact: bool = False, yesno: bool = False) -> list:
+    if not isinstance(value, bool):
+        raise TypeError(f"Expected a boolean value, got {type(value).__name__}")
+
+    if not yesno and not value:
+        return []
+
+    if compact and value:
+        return [key]
+
+    if yesno:
+        return [key, 'yes' if value else 'no']
+
+    return [key, 'yes']
+
 

--- a/src/kiutils/utils/sexpr.py
+++ b/src/kiutils/utils/sexpr.py
@@ -42,6 +42,16 @@ def parse_sexp(sexp):
     assert not stack, "Trouble with nesting of brackets"
     return out[0]
 
+def sexp_to_string(expr) -> str:
+    """Convert a nested list-based S-expression into a raw string."""
+    if isinstance(expr, list):
+        if len(expr) < 1:
+            return ''
+        else:
+            return '(' + ' '.join(sexp_to_string(item) for item in expr) + ')'
+
+    return str(expr)
+
 """
 Nearly a line-by-line translation of KiCad's C++ "Prettify" function (commit id: 1ec47a053baf50c3d7b57a0efbbd2d4dfc03fb6e)
 Source: https://gitlab.com/kicad/code/kicad/-/blob/master/common/io/kicad/kicad_io_utils.cpp

--- a/src/kiutils/utils/string_utils.py
+++ b/src/kiutils/utils/string_utils.py
@@ -21,6 +21,27 @@ def dequote(input: str) -> str:
     """
     return str(input).replace("\"", "\\\"")
 
+def quote(s: str) -> str:
+    """Wraps a string in double quotes without escaping internal quotes
+
+    Args:
+        - s (str): Input string to wrap
+
+    Returns:
+        - str: String wrapped in double quotes
+    """
+    return f'"{s}"'
+
+def escape_and_quote(s: str) -> str:
+    """Escapes double-quotes in a string using the external `dequote` function and wraps the result in double quotes
+
+    Args:
+        - s (str): Input string to escape and quote
+
+    Returns:
+        - str: Escaped string wrapped in double quotes
+    """
+    return f'"{dequote(s)}"'
 
 def remove_prefix(input: str, prefix: str) -> str:
     """Removes the given prefix from a string (to remove incompatibility of ``str.removeprefix()``

--- a/src/kiutils/wks.py
+++ b/src/kiutils/wks.py
@@ -20,12 +20,11 @@ from typing import Optional, List
 from os import path
 
 from kiutils.items.common import Justify
-from kiutils.utils.string_utils import dequote
-from kiutils.utils import sexpr
-from kiutils.utils.sexpr import sexp_prettify as prettify
+from kiutils.utils.string_utils import *
+from kiutils.utils.sexpr import sexp_prettify as prettify, sexp_to_string, parse_sexp
 from kiutils.misc.config import *
 from kiutils.utils.format_utils import format_float
-from kiutils.utils.parsing_utils import parse_bool, format_bool
+from kiutils.utils.parsing_utils import parse_bool, format_bool_raw
 
 @dataclass
 class WksFontSize():
@@ -73,9 +72,13 @@ class WksFontSize():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        return f'{indents}(size {self.width} {self.height}){endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        expr = ['size', format_float(self.width), format_float(self.height)]
+        return expr
+
 
 @dataclass
 class WksFont():
@@ -137,18 +140,30 @@ class WksFont():
             - str: S-Expression of this object. Will return an empty string, if all members of this
                    class are set to ``None``.
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        lw = f' (linewidth {self.linewidth})' if self.linewidth is not None else ''
-        size = f' {self.size.to_sexpr()}' if self.size is not None else ''
-        bold = format_bool('bold', self.bold, compact=True)
-        italic = format_bool('italic', self.italic, compact=True)
+    def _to_sexpr_raw(self):
+        expr = ['font']
 
-        if lw == '' and size == '' and bold == '' and italic == '':
-            return ''
-        else:
-            return f'{indents}(font{lw}{size} {bold} {italic}){endline}'
+        if self.linewidth is not None:
+            expr.append(['linewidth', format_float(self.linewidth)])
+
+        if self.size is not None:
+            expr.append(self.size._to_sexpr_raw())
+
+        if self.bold:
+            expr.extend(format_bool_raw('bold', self.bold, compact=True))
+
+        if self.italic:
+            expr.extend(format_bool_raw('italic', self.italic, compact=True))
+
+        # Return an empty expression if no attributes are present
+        if len(expr) == 1:  # Just ['font']
+            return []
+
+        return expr
+
 
 @dataclass
 class WksPosition():
@@ -281,23 +296,41 @@ class Line():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        start_corner = f' {self.start.corner}' if self.start.corner is not None else ''
-        end_corner = f' {self.end.corner}' if self.end.corner is not None else ''
-        option = f' (option {self.option})' if self.option is not None else ''
-        repeat = f' (repeat {self.repeat})' if self.repeat is not None else ''
-        incrx = f' (incrx {self.incrx})' if self.incrx is not None else ''
-        incry = f' (incry {self.incry})' if self.incry is not None else ''
-        comment = f' (comment "{dequote(self.comment)}")\n' if self.comment is not None else ''
-        lw = f' (linewidth {self.lineWidth})' if self.lineWidth is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'line',
+            ['name', escape_and_quote(self.name)],
+        ]
 
-        expression  = f'{indents}(line (name "{dequote(self.name)}") '
-        expression += f'(start {self.start.X} {self.start.Y}{start_corner}) '
-        expression += f'(end {self.end.X} {self.end.Y}{end_corner})'
-        expression += f'{option}{lw}{repeat}{incrx}{incry}{comment}){endline}'
-        return expression
+        # Add start and end coordinates and corner info
+        start_corner = ['start', format_float(self.start.X), format_float(self.start.Y)]
+        if self.start.corner is not None:
+            start_corner.append(self.start.corner)
+        expr.append(start_corner)
+
+        end_corner = ['end', format_float(self.end.X), format_float(self.end.Y)]
+        if self.end.corner is not None:
+            end_corner.append(self.end.corner)
+        expr.append(end_corner)
+
+        if self.option is not None:
+            expr.append(['option', self.option])
+        if self.lineWidth is not None:
+            expr.append(['linewidth', format_float(self.lineWidth)])
+        if self.repeat is not None:
+            expr.append(['repeat', self.repeat])
+        if self.incrx is not None:
+            expr.append(['incrx', format_float(self.incrx)])
+        if self.incry is not None:
+            expr.append(['incry', format_float(self.incry)])
+        if self.comment is not None:
+            expr.append(['comment', escape_and_quote(self.comment)])
+
+        return expr
+
 
 @dataclass
 class Rect():
@@ -380,23 +413,41 @@ class Rect():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        start_corner = f' {self.start.corner}' if self.start.corner is not None else ''
-        end_corner = f' {self.end.corner}' if self.end.corner is not None else ''
-        option = f' (option {self.option})' if self.option is not None else ''
-        repeat = f' (repeat {self.repeat})' if self.repeat is not None else ''
-        incrx = f' (incrx {self.incrx})' if self.incrx is not None else ''
-        incry = f' (incry {self.incry})' if self.incry is not None else ''
-        comment = f' (comment "{dequote(self.comment)}")\n' if self.comment is not None else ''
-        lw = f' (linewidth {self.lineWidth})' if self.lineWidth is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'rect',
+            ['name', escape_and_quote(self.name)],
+        ]
 
-        expression  = f'{indents}(rect (name "{dequote(self.name)}") '
-        expression += f'(start {format_float(self.start.X)} {format_float(self.start.Y)}{start_corner}) '
-        expression += f'(end {format_float(self.end.X)} {format_float(self.end.Y)}{end_corner})'
-        expression += f'{option}{lw}{repeat}{incrx}{incry}{comment}){endline}'
-        return expression
+        # Add start and end coordinates and corner info
+        start_corner = ['start', format_float(self.start.X), format_float(self.start.Y)]
+        if self.start.corner is not None:
+            start_corner.append(self.start.corner)
+        expr.append(start_corner)
+
+        end_corner = ['end', format_float(self.end.X), format_float(self.end.Y)]
+        if self.end.corner is not None:
+            end_corner.append(self.end.corner)
+        expr.append(end_corner)
+
+        if self.option is not None:
+            expr.append(['option', self.option])
+        if self.lineWidth is not None:
+            expr.append(['linewidth', format_float(self.lineWidth)])
+        if self.repeat is not None:
+            expr.append(['repeat', self.repeat])
+        if self.incrx is not None:
+            expr.append(['incrx', format_float(self.incrx)])
+        if self.incry is not None:
+            expr.append(['incry', format_float(self.incry)])
+        if self.comment is not None:
+            expr.append(['comment', escape_and_quote(self.comment)])
+
+        return expr
+
 
 @dataclass
 class Polygon():
@@ -553,27 +604,40 @@ class Bitmap():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        repeat = f' (repeat {self.repeat})' if self.repeat is not None else ''
-        incrx = f' (incrx {self.incrx})' if self.incrx is not None else ''
-        incry = f' (incry {self.incry})' if self.incry is not None else ''
-        option = f' (option {self.option})' if self.option is not None else ''
-        corner = f' {self.position.corner}' if self.position.corner is not None else ''
+    def _to_sexpr_raw(self):
+        expr = [
+            'bitmap',
+            ['name', escape_and_quote(self.name)],
+        ]
 
-        expression  = f'{indents}(bitmap (name "{dequote(self.name)}") '
-        expression += f'(pos {format_float(self.position.X)} {format_float(self.position.Y)}{corner}){option} (scale {self.scale})'
-        expression += f'{repeat}{incrx}{incry}\n'
+        pos = ['pos', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.corner is not None:
+            pos.append(self.position.corner)
+        expr.append(pos)
+
+        if self.option is not None:
+            expr.append(['option', self.option])
+
+        expr.append(['scale', self.scale])
+
+        if self.repeat is not None:
+            expr.append(['repeat', self.repeat])
+        if self.incrx is not None:
+            expr.append(['incrx', self.incrx])
+        if self.incry is not None:
+            expr.append(['incry', self.incry])
         if self.comment is not None:
-            # Here KiCad decides to only use 1 space for some unknown reason ..
-            expression += f' (comment "{dequote(self.comment)}")\n'
-        if len(self.data) > 0:
-            data_str = ' '.join(f'"{d}"' for d in self.data)
-            expression += f'{indents}(data {data_str})\n'
-        expression += f'{indents}){endline}'
-        return expression
+            expr.append(['comment', escape_and_quote(self.comment)])
 
+        # Add data if it exists
+        if len(self.data) > 0:
+            data_str = ' '.join(quote(d) for d in self.data)
+            expr.append(['data', data_str])
+
+        return expr
 
 @dataclass
 class TbText():
@@ -682,28 +746,44 @@ class TbText():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        corner = f' {self.position.corner}' if self.position.corner is not None else ''
-        repeat = f' (repeat {self.repeat})' if self.repeat is not None else ''
-        incrx = f' (incrx {self.incrx})' if self.incrx is not None else ''
-        incry = f' (incry {self.incry})' if self.incry is not None else ''
-        option = f' (option {self.option})' if self.option is not None else ''
-        rotate = f' (rotate {self.rotate})' if self.rotate is not None else ''
-        justify = f' {self.justify.to_sexpr()}' if self.justify is not None else ''
-        maxlen = f' (maxlen {self.maxlen})' if self.maxlen is not None else ''
-        maxheight = f' (maxheight {self.maxheight})' if self.maxheight is not None else ''
-        incrlabel = f' (incrlabel {self.incrlabel})' if self.incrlabel is not None else ''
-        font = f' {self.font.to_sexpr()}'
+    def _to_sexpr_raw(self):
+        expr = [
+            'tbtext', escape_and_quote(self.text),
+            ['name', escape_and_quote(self.name)],
+        ]
 
-        expression  = f'{indents}(tbtext "{dequote(self.text)}" (name "{dequote(self.name)}") '
-        expression += f'(pos {format_float(self.position.X)} {format_float(self.position.Y)}{corner}){option}{rotate}'
-        expression += f'{font}{justify}{maxlen}{maxheight}{repeat}{incrx}{incry}{incrlabel}'
+        pos = ['pos', format_float(self.position.X), format_float(self.position.Y)]
+        if self.position.corner is not None:
+            pos.append(self.position.corner)
+        expr.append(pos)
+
+        if self.option is not None:
+            expr.append(['option', self.option])
+        if self.rotate is not None:
+            expr.append(['rotate', self.rotate])
+        if self.font is not None:
+            expr.append(self.font._to_sexpr_raw())
+        if self.justify is not None:
+            expr.append(self.justify._to_sexpr_raw())
+        if self.maxlen is not None:
+            expr.append(['maxlen', self.maxlen])
+        if self.maxheight is not None:
+            expr.append(['maxheight', self.maxheight])
+        if self.repeat is not None:
+            expr.append(['repeat', self.repeat])
+        if self.incrx is not None:
+            expr.append(['incrx', self.incrx])
+        if self.incry is not None:
+            expr.append(['incry', self.incry])
+        if self.incrlabel is not None:
+            expr.append(['incrlabel', self.incrlabel])
         if self.comment is not None:
-            expression += f' (comment "{dequote(self.comment)}")\n'
-        expression += f'){endline}'
-        return expression
+            expr.append(['comment', escape_and_quote(self.comment)])
+
+        return expr
 
 
 @dataclass
@@ -752,9 +832,11 @@ class TextSize():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
-        return f'{indents}(textsize {self.width} {self.height}){endline}'
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
+
+    def _to_sexpr_raw(self):
+        return ['textsize', format_float(self.width), format_float(self.height)]
 
 @dataclass
 class Setup():
@@ -831,17 +913,22 @@ class Setup():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        # KiCad puts no spaces between tokens here
-        expression =  f'{indents}(setup {self.textSize.to_sexpr()}(linewidth {self.lineWidth})'
-        expression += f'(textlinewidth {self.textLineWidth})\n{indents}'
-        expression += f'(left_margin {self.leftMargin})(right_margin {self.rightMargin})'
-        expression += f'(top_margin {self.topMargin})(bottom_margin {self.bottomMargin})'
-        expression += f'){endline}'
+    def _to_sexpr_raw(self):
+        expr = ['setup']
 
-        return expression
+        expr.append(self.textSize._to_sexpr_raw())
+        expr.append(['linewidth', self.lineWidth])
+        expr.append(['textlinewidth', self.textLineWidth])
+        expr.append(['left_margin', self.leftMargin])
+        expr.append(['right_margin', self.rightMargin])
+        expr.append(['top_margin', self.topMargin])
+        expr.append(['bottom_margin', self.bottomMargin])
+
+        return expr
+
 
 @dataclass
 class WorkSheet():
@@ -931,7 +1018,7 @@ class WorkSheet():
             raise Exception("Given path is not a file!")
 
         with open(filepath, 'r', encoding=encoding) as infile:
-            item = cls.from_sexpr(sexpr.parse_sexp(infile.read()))
+            item = cls.from_sexpr(parse_sexp(infile.read()))
             item.filePath = filepath
             return item
 
@@ -977,16 +1064,22 @@ class WorkSheet():
         Returns:
             - str: S-Expression of this object
         """
-        indents = ' '*indent
-        endline = '\n' if newline else ''
+        raw_expr = self._to_sexpr_raw()
+        return sexp_to_string(raw_expr)
 
-        generator_version = f' (generator_version "{self.generator_version}")' if self.generator_version is not None else ''
-        embedded_fonts = f' {format_bool("embedded_fonts", self.embedded_fonts, compact=False, yesno=True)}' if self.embedded_fonts is not None else ''
+    def _to_sexpr_raw(self):
+        expr = ['kicad_wks']
 
-        expression =  f'{indents}(kicad_wks (version {self.version}) (generator "{self.generator}"){generator_version}{embedded_fonts}\n'
-        expression += self.setup.to_sexpr(indent+2)
+        expr.append(['version', self.version])
+        expr.append(['generator', quote(self.generator)])
+        if self.generator_version:
+            expr.append(['generator_version', quote(self.generator_version)])
+
+        if self.embedded_fonts is not None:
+            expr.append(format_bool_raw(self.embedded_fonts, compact=False, yesno=True))
+
+        expr.append(self.setup._to_sexpr_raw())
         for item in self.drawingObjects:
-            expression += item.to_sexpr(indent+2)
-        expression += f'{indents}){endline}'
+            expr.append(item._to_sexpr_raw())
 
-        return expression
+        return expr


### PR DESCRIPTION
The goal of this pull request is to refactor clunky s-expression handling for all elements, most notably `to_sexpr` functions. Since we are already for some time using external (copy of KiCad's own) s-expression prettifier, we do not have to care anymore about indenting our strings, or entering new line at the right moment.

This pull request drops this behaviour and moves focus of creating s-expressions in a list-like, linear fashion.
Parameters `indents` and `newline` will be left for now though, to ensure backwards compatibility, although they will (this is true for last few months too, by the way) do nothing.

We want to make sure that anyone can extend these functions/expressions. They do not have to behave like s-expression parsers themselves and care about indentations, braces, etc.